### PR TITLE
Fix README repository name

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Une application web moderne et complète pour la gestion de factures, développ�
 
 1. **Cloner ou télécharger le projet**
    ```bash
-   cd billing-app
+   cd Mam-s-Facture
    ```
 
 2. **Installer les dépendances du backend**
@@ -75,7 +75,7 @@ Une application web moderne et complète pour la gestion de factures, développ�
 ## 📁 Structure du projet
 
 ```
-billing-app/
+Mam-s-Facture/
 ├── backend/                    # API Node.js/Express
 │   ├── database/              # Système de stockage JSON
 │   │   ├── storage.js         # Gestionnaire de base de données JSON


### PR DESCRIPTION
## Summary
- correct project folder name in README install step
- update project tree to match folder name

## Testing
- `pnpm install` in backend
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68560a4876ac832fa9a01ec17490bf03