### PR TITLE
Handle lignes separately

### DIFF
--- a/backend/database/data/factures.json
+++ b/backend/database/data/factures.json
@@ -8,13 +8,6 @@
     "adresse": "2 rue de Ludres, Vandœuvre-lès-Nancy \n54500, France",
     "date_facture": "2025-06-20",
     "montant_total": 100,
-    "lignes": [
-      {
-        "description": "création d'un logiciel de facturation ",
-        "quantite": 1,
-        "prix_unitaire": 100
-      }
-    ],
     "created_at": "2025-06-20T18:53:15.382Z",
     "updated_at": "2025-06-20T18:53:15.382Z"
   }

--- a/backend/database/storage.js
+++ b/backend/database/storage.js
@@ -194,11 +194,13 @@ class JSONDatabase {
       rcs_number: data.rcs_number || ''
     };
 
+    const { lignes: lignesData = [], ...factureSansLignes } = data;
+
     const now = new Date().toISOString();
     const nouveauFacture = {
       id: newId,
       ...defaultFields,
-      ...data,
+      ...factureSansLignes,
       created_at: now,
       updated_at: now
     };
@@ -206,7 +208,7 @@ class JSONDatabase {
     factures.push(nouveauFacture);
 
     // Ajouter les lignes
-    const nouvelleLignes = data.lignes.map((ligne, index) => ({
+    const nouvelleLignes = lignesData.map((ligne, index) => ({
       id: lignes.length > 0 ? Math.max(...lignes.map(l => l.id)) + 1 + index : 1 + index,
       facture_id: newId,
       description: ligne.description,
@@ -232,9 +234,11 @@ class JSONDatabase {
     if (index === -1) return false;
 
     // Mettre à jour la facture
+    const { lignes: lignesData = [], ...factureSansLignes } = data;
+
     factures[index] = {
       ...factures[index],
-      ...data,
+      ...factureSansLignes,
       id: parseInt(id),
       updated_at: new Date().toISOString()
     };
@@ -243,7 +247,7 @@ class JSONDatabase {
     const lignesFiltered = lignes.filter(l => l.facture_id !== parseInt(id));
     
     // Ajouter les nouvelles lignes
-    const nouvelleLignes = data.lignes.map((ligne, ligneIndex) => ({
+    const nouvelleLignes = lignesData.map((ligne, ligneIndex) => ({
       id: lignes.length > 0 ? Math.max(...lignes.map(l => l.id)) + 1 + ligneIndex : 1 + ligneIndex,
       facture_id: parseInt(id),
       description: ligne.description,


### PR DESCRIPTION
## Summary
- exclude `lignes` from invoices stored in factures.json
- keep line items only in lignes.json

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68560a4b8bdc832f8a28fd2edbc2b630