### PR TITLE
Wrap data loaders in useCallback

### DIFF
--- a/frontend/src/pages/DetailFacture.tsx
+++ b/frontend/src/pages/DetailFacture.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { Link, useParams, useNavigate } from 'react-router-dom';
 import { ArrowLeft, Edit, Download, Trash2, FileText, User, Calendar, Euro } from 'lucide-react';
 
@@ -33,7 +33,7 @@ export default function DetailFacture() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  const chargerFacture = async () => {
+  const chargerFacture = useCallback(async () => {
     try {
       setLoading(true);
       const response = await fetch(`http://localhost:3001/api/factures/${id}`);
@@ -54,13 +54,13 @@ export default function DetailFacture() {
     } finally {
       setLoading(false);
     }
-  };
+  }, [id]);
 
   useEffect(() => {
     if (id) {
       chargerFacture();
     }
-  }, [id]);
+  }, [id, chargerFacture]);
 
   const supprimerFacture = async () => {
     if (!facture || !confirm(`Êtes-vous sûr de vouloir supprimer la facture ${facture.numero_facture} ?`)) {

--- a/frontend/src/pages/ListeFactures.tsx
+++ b/frontend/src/pages/ListeFactures.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { Link } from 'react-router-dom';
 import { Search, Filter, FileText, Plus, Eye, Edit, Trash2, Download, ArrowLeft, Calendar } from 'lucide-react';
 
@@ -37,7 +37,7 @@ export default function ListeFactures() {
   const [dateDebut, setDateDebut] = useState('');
   const [dateFin, setDateFin] = useState('');
 
-  const chargerFactures = async () => {
+  const chargerFactures = useCallback(async () => {
     try {
       setLoading(true);
       const params = new URLSearchParams({
@@ -61,11 +61,11 @@ export default function ListeFactures() {
     } finally {
       setLoading(false);
     }
-  };
+  }, [pagination.page, pagination.limit, recherche, dateDebut, dateFin]);
 
   useEffect(() => {
     chargerFactures();
-  }, [pagination.page, recherche, dateDebut, dateFin]);
+  }, [chargerFactures]);
 
   const supprimerFacture = async (id: number, numeroFacture: string) => {
     if (!confirm(`Êtes-vous sûr de vouloir supprimer la facture ${numeroFacture} ?`)) {

--- a/frontend/src/pages/ModifierFacture.tsx
+++ b/frontend/src/pages/ModifierFacture.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { Link, useParams, useNavigate } from 'react-router-dom';
 import { ArrowLeft, Plus, Trash2, Save, Calculator } from 'lucide-react';
 
@@ -46,7 +46,7 @@ export default function ModifierFacture() {
   const [factureOriginale, setFactureOriginale] = useState<Facture | null>(null);
 
   // Charger la facture existante
-  const chargerFacture = async () => {
+  const chargerFacture = useCallback(async () => {
     try {
       setLoading(true);
       const response = await fetch(`http://localhost:3001/api/factures/${id}`);
@@ -79,13 +79,13 @@ export default function ModifierFacture() {
     } finally {
       setLoading(false);
     }
-  };
+  }, [id, navigate]);
 
   useEffect(() => {
     if (id) {
       chargerFacture();
     }
-  }, [id]);
+  }, [id, chargerFacture]);
 
   // Calcul du montant total
   const montantTotal = lignes.reduce((total, ligne) => {


### PR DESCRIPTION
## Summary
- wrap loader functions in `useCallback`
- include callbacks in `useEffect` dependencies
- include loader dependencies

## Testing
- `pnpm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68560d496fa4832fa6d76a59c4082060