### PR TITLE
Add install script for easy setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,17 @@ Une application web moderne et complète pour la gestion de factures, développ�
 - Node.js 18+ 
 - pnpm (ou npm)
 
-### Installation
+### Installation rapide
+
+Exécutez le script `install.sh` à la racine du projet. Il détecte
+automatiquement `pnpm` (ou `npm`) et installe toutes les dépendances
+avant de construire l'interface :
+
+```bash
+./install.sh
+```
+
+### Installation manuelle
 
 1. **Cloner ou télécharger le projet**
    ```bash

--- a/frontend/src/components/ui/sidebar.tsx
+++ b/frontend/src/components/ui/sidebar.tsx
@@ -16,7 +16,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip"
-import { SidebarContext, useSidebar } from "./sidebar-utils"
+import { SidebarContext, SidebarContextValue, useSidebar } from "./sidebar-utils"
 
 const SIDEBAR_COOKIE_NAME = "sidebar:state"
 const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7
@@ -94,7 +94,7 @@ const SidebarProvider = React.forwardRef<
     // This makes it easier to style the sidebar with Tailwind classes.
     const state = open ? "expanded" : "collapsed"
 
-    const contextValue = React.useMemo<SidebarContext>(
+    const contextValue = React.useMemo<SidebarContextValue>(
       () => ({
         state,
         open,

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -e
+
+# Detect package manager (prefer pnpm, fallback to npm)
+if command -v pnpm >/dev/null 2>&1; then
+  PM=pnpm
+else
+  PM=npm
+fi
+
+echo "[installer] Utilisation de $PM pour installer les dépendances"
+
+# Installer backend
+echo "[installer] Installation des dépendances backend..."
+(cd backend && "$PM" install)
+
+# Installer frontend
+echo "[installer] Installation des dépendances frontend..."
+(cd frontend && "$PM" install)
+
+# Construire le frontend
+echo "[installer] Construction du frontend..."
+(cd frontend && "$PM" run build)
+
+echo "[installer] Installation terminée."
+
+echo "Vous pouvez démarrer le backend avec : (cd backend && $PM start)"
+echo "Et lancer le frontend en mode développement : (cd frontend && $PM run dev)"


### PR DESCRIPTION
## Summary
- add `install.sh` to install backend and frontend deps
- update sidebar context typing
- document quick installation in README

## Testing
- `./install.sh`
- `cd backend && pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68560fac6100832fac2cc28469109c2b