### PR TITLE
Update READMEs with installer info

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Une application web moderne et complète pour la gestion de factures, développée avec React, Node.js, et stockage JSON. Interface entièrement en français avec génération de PDF professionnels.
 
+Pour une installation simplifiée, lancez `./install.sh` à la racine du projet. Ce script installe toutes les dépendances et construit automatiquement le frontend.
+
 ## 🌟 Fonctionnalités principales
 
 ### ✅ Interface utilisateur complète
@@ -38,9 +40,7 @@ Une application web moderne et complète pour la gestion de factures, développ�
 
 ### Installation rapide
 
-Exécutez le script `install.sh` à la racine du projet. Il détecte
-automatiquement `pnpm` (ou `npm`) et installe toutes les dépendances
-avant de construire l'interface :
+Exécutez le script `install.sh` à la racine du projet. Il détecte automatiquement `pnpm` (ou `npm`), gère l'installation du backend et du frontend, puis construit ce dernier :
 
 ```bash
 ./install.sh

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,5 +1,7 @@
 # React + TypeScript + Vite
 
+This frontend is part of the **Mam-s-Facture** application. You can install all dependencies at once by running `../install.sh` from the project root.
+
 This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
 
 Currently, two official plugins are available:


### PR DESCRIPTION
## Summary
- mention `install.sh` usage at the top of the main README
- clarify automatic installer steps in installation section
- add a note in frontend README about running the installer from project root

## Testing
- `./install.sh` (build and install)
- `pnpm test` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_685610d93cc8832fa17baea4f96fa960