### PR TITLE
Add sidebar navigation and theme setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ Pour une installation simplifiée, lancez `./install.sh` à la racine du projet.
 
 ## 🌟 Fonctionnalités principales
 
-### ✅ Interface utilisateur complète
-- **Page d'accueil** avec navigation intuitive
+-### ✅ Interface utilisateur complète
+- **Page d'accueil** avec navigation intuitive et barre latérale
 - **Gestion complète des factures** (CRUD)
 - **Recherche et filtrage** par client, période, montant
 - **Pagination** pour une navigation fluide
@@ -78,9 +78,17 @@ Exécutez le script `install.sh` à la racine du projet. Il détecte automatique
 2. **Démarrer l'interface frontend**
    ```bash
    cd frontend
-   pnpm run dev
-   ```
-   L'application est accessible sur http://localhost:5173
+  pnpm run dev
+  ```
+  L'application est accessible sur http://localhost:5173
+
+### Migration de la base de données
+Un script est fourni pour ajouter les nouveaux champs légaux aux anciennes factures :
+
+```bash
+cd backend
+node database/migrations/002-add-legal-fields.js
+```
 
 ## 📁 Structure du projet
 
@@ -166,6 +174,7 @@ Mam-s-Facture/
 - **Feedback visuel** : Confirmations et messages d'état
 - **Responsive design** : Fonctionne sur mobile et desktop
 - **Performance** : Chargement rapide avec pagination
+- **Thèmes** : Sunset (par défaut), Light et Dark sélectionnables depuis la barre latérale
 
 ## 🛠️ Développement
 
@@ -174,6 +183,7 @@ L'application inclut des données d'exemple pour la démonstration :
 - 3 factures pré-créées avec différents clients
 - Lignes de facturation variées
 - Montants et dates réalistes
+- Les factures comportent désormais un titre, des informations légales et un statut payé/non payé
 
 ### Personnalisation
 - **Informations entreprise** : Modifiables dans `server.js` (section PDF)

--- a/backend/database/migrations/002-add-legal-fields.js
+++ b/backend/database/migrations/002-add-legal-fields.js
@@ -1,0 +1,20 @@
+const fs = require('fs')
+const path = require('path')
+
+const file = path.join(__dirname, '..', 'data', 'factures.json')
+const factures = JSON.parse(fs.readFileSync(file, 'utf8'))
+
+const updated = factures.map(f => ({
+  title: f.title || `Facture #${f.id}`,
+  status: f.status || 'unpaid',
+  logo_path: f.logo_path || '',
+  siren: f.siren || '',
+  siret: f.siret || '',
+  legal_form: f.legal_form || '',
+  vat_number: f.vat_number || '',
+  rcs_number: f.rcs_number || '',
+  ...f
+}))
+
+fs.writeFileSync(file, JSON.stringify(updated, null, 2))
+console.log('Migration 002 terminée')

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,21 +6,28 @@ import CreerFacture from './pages/CreerFacture'
 import ModifierFacture from './pages/ModifierFacture'
 import DetailFacture from './pages/DetailFacture'
 import { ErrorBoundary } from './components/ErrorBoundary'
+import Sidebar from './components/Sidebar'
+import { ThemeProvider } from './context/ThemeContext'
 
 function App() {
   return (
     <ErrorBoundary>
-      <Router>
-        <div className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100">
-          <Routes>
-            <Route path="/" element={<Accueil />} />
-            <Route path="/factures" element={<ListeFactures />} />
-            <Route path="/factures/nouvelle" element={<CreerFacture />} />
-            <Route path="/factures/:id" element={<DetailFacture />} />
-            <Route path="/factures/:id/modifier" element={<ModifierFacture />} />
-          </Routes>
-        </div>
-      </Router>
+      <ThemeProvider>
+        <Router>
+          <div className="flex">
+            <Sidebar />
+            <main className="ml-64 flex-1 min-h-screen p-0">
+              <Routes>
+                <Route path="/" element={<Accueil />} />
+                <Route path="/factures" element={<ListeFactures />} />
+                <Route path="/factures/nouvelle" element={<CreerFacture />} />
+                <Route path="/factures/:id" element={<DetailFacture />} />
+                <Route path="/factures/:id/modifier" element={<ModifierFacture />} />
+              </Routes>
+            </main>
+          </div>
+        </Router>
+      </ThemeProvider>
     </ErrorBoundary>
   )
 }

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -1,0 +1,34 @@
+import { NavLink } from 'react-router-dom'
+import { Home, FileText, PlusCircle, CircleAlert, Sun } from 'lucide-react'
+import { useTheme } from '../context/ThemeContext'
+
+export default function Sidebar() {
+  const { theme, toggleTheme } = useTheme()
+
+  return (
+    <aside className="fixed left-0 top-0 h-full w-64 bg-sidebar p-6 text-sidebar-foreground shadow-lg">
+      <nav className="space-y-4">
+        <NavLink to="/" className="flex items-center space-x-2 hover:text-primary">
+          <Home className="h-5 w-5" />
+          <span>Accueil</span>
+        </NavLink>
+        <NavLink to="/factures" className="flex items-center space-x-2 hover:text-primary">
+          <FileText className="h-5 w-5" />
+          <span>Voir les factures</span>
+        </NavLink>
+        <NavLink to="/factures/nouvelle" className="flex items-center space-x-2 hover:text-primary">
+          <PlusCircle className="h-5 w-5" />
+          <span>Créer une facture</span>
+        </NavLink>
+        <NavLink to="/factures?status=unpaid" className="flex items-center space-x-2 hover:text-primary">
+          <CircleAlert className="h-5 w-5" />
+          <span>Factures non payées</span>
+        </NavLink>
+        <button onClick={toggleTheme} className="flex items-center space-x-2 hover:text-primary">
+          <Sun className="h-5 w-5" />
+          <span>Changer le thème ({theme})</span>
+        </button>
+      </nav>
+    </aside>
+  )
+}

--- a/frontend/src/context/ThemeContext.tsx
+++ b/frontend/src/context/ThemeContext.tsx
@@ -1,0 +1,37 @@
+import React, { useState, useEffect, createContext, useContext } from 'react'
+
+export type Theme = 'sunset' | 'light' | 'dark'
+
+interface ThemeContextValue {
+  theme: Theme
+  setTheme: (t: Theme) => void
+  toggleTheme: () => void
+}
+
+const ThemeContext = createContext<ThemeContextValue | undefined>(undefined)
+
+export const ThemeProvider = ({ children }: { children: React.ReactNode }) => {
+  const [theme, setTheme] = useState<Theme>('sunset')
+
+  useEffect(() => {
+    const cls = `theme-${theme}`
+    document.documentElement.classList.remove('theme-sunset', 'theme-light', 'theme-dark')
+    document.documentElement.classList.add(cls)
+  }, [theme])
+
+  const toggleTheme = () => {
+    setTheme((prev) => (prev === 'sunset' ? 'light' : prev === 'light' ? 'dark' : 'sunset'))
+  }
+
+  return (
+    <ThemeContext.Provider value={{ theme, setTheme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  )
+}
+
+export const useTheme = () => {
+  const ctx = useContext(ThemeContext)
+  if (!ctx) throw new Error('useTheme must be used within ThemeProvider')
+  return ctx
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -13,6 +13,9 @@
     --sidebar-accent-foreground: 240 5.9% 10%;
     --sidebar-border: 220 13% 91%;
     --sidebar-ring: 217.2 91.2% 59.8%
+    --gradient-start: #f97316;
+    --gradient-mid: #ec4899;
+    --gradient-end: #8b5cf6;
   }
 
   .dark {
@@ -25,6 +28,28 @@
     --sidebar-border: 240 3.7% 15.9%;
     --sidebar-ring: 217.2 91.2% 59.8%
   }
+
+  .theme-sunset {
+    --background: var(--gradient-start);
+  }
+  .theme-light {
+    --background: white;
+  }
+  .theme-dark {
+    --background: #1f2937;
+    --foreground: #f9fafb;
+  }
+}
+
+body.theme-sunset {
+  background-image: linear-gradient(to bottom, var(--gradient-start), var(--gradient-mid), var(--gradient-end));
+}
+body.theme-light {
+  background-color: white;
+}
+body.theme-dark {
+  background-color: #1f2937;
+  color: var(--foreground);
 }
 
 

--- a/frontend/src/pages/Accueil.tsx
+++ b/frontend/src/pages/Accueil.tsx
@@ -26,11 +26,11 @@ export default function Accueil() {
         {/* Hero Section */}
         <div className="text-center mb-16">
           <h2 className="text-4xl font-extrabold text-gray-900 sm:text-5xl md:text-6xl">
-            Bienvenue dans votre
-            <span className="text-indigo-600 block">espace facturation</span>
+            Bienvenue dans votre espace de facturation,{' '}
+            <span className="text-indigo-600">Caroline MIRRE</span>
           </h2>
           <p className="mt-6 max-w-2xl mx-auto text-xl text-gray-600">
-            Gérez vos factures facilement avec notre solution complète. 
+            Gérez vos factures facilement avec notre solution complète.
             Créez, modifiez et exportez vos factures en quelques clics.
           </p>
         </div>
@@ -40,7 +40,7 @@ export default function Accueil() {
           {/* Voir les factures */}
           <Link
             to="/factures"
-            className="group relative bg-white rounded-2xl p-8 shadow-lg hover:shadow-xl transition-all duration-300 border border-gray-100 hover:border-indigo-200"
+            className="group relative bg-gradient-to-br from-[var(--gradient-start)] via-[var(--gradient-mid)] to-[var(--gradient-end)] text-white rounded-2xl p-8 shadow-lg hover:shadow-xl transition-all duration-300"
           >
             <div className="flex items-center justify-center w-16 h-16 bg-indigo-100 rounded-xl mb-6 group-hover:bg-indigo-200 transition-colors">
               <FileText className="h-8 w-8 text-indigo-600" />
@@ -63,7 +63,7 @@ export default function Accueil() {
           {/* Créer une nouvelle facture */}
           <Link
             to="/factures/nouvelle"
-            className="group relative bg-gradient-to-br from-indigo-500 to-purple-600 rounded-2xl p-8 shadow-lg hover:shadow-xl transition-all duration-300 text-white"
+            className="group relative bg-gradient-to-br from-[var(--gradient-start)] via-[var(--gradient-mid)] to-[var(--gradient-end)] rounded-2xl p-8 shadow-lg hover:shadow-xl transition-all duration-300 text-white"
           >
             <div className="flex items-center justify-center w-16 h-16 bg-white bg-opacity-20 rounded-xl mb-6 group-hover:bg-opacity-30 transition-colors">
               <Plus className="h-8 w-8 text-white" />


### PR DESCRIPTION
## Summary
- create sidebar component with navigation and theme switcher
- implement `ThemeProvider` and CSS theme variables
- update hero message on dashboard
- extend backend to store legal fields and status
- provide migration script for existing invoices
- update README with theme instructions and migration guide

## Testing
- `pnpm install` in `backend`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6856143483c0832fb47f092e0f961e00