### PR TITLE
Add VAT rate support

### DIFF
--- a/backend/database/data/factures.json
+++ b/backend/database/data/factures.json
@@ -8,6 +8,7 @@
     "adresse": "2 rue de Ludres, Vandœuvre-lès-Nancy \n54500, France",
     "date_facture": "2025-06-20",
     "montant_total": 100,
+    "vat_rate": 20,
     "created_at": "2025-06-20T18:53:15.382Z",
     "updated_at": "2025-06-20T18:53:15.382Z"
   }

--- a/backend/database/storage.js
+++ b/backend/database/storage.js
@@ -35,6 +35,7 @@ class JSONDatabase {
           siret: '12345678900011',
           legal_form: 'SARL',
           vat_number: 'FR123456789',
+          vat_rate: 20,
           rcs_number: 'Paris B 123456789',
           created_at: new Date().toISOString(),
           updated_at: new Date().toISOString()
@@ -55,6 +56,7 @@ class JSONDatabase {
           siret: '12345678900011',
           legal_form: 'SARL',
           vat_number: 'FR123456789',
+          vat_rate: 20,
           rcs_number: 'Paris B 123456789',
           created_at: new Date().toISOString(),
           updated_at: new Date().toISOString()
@@ -75,6 +77,7 @@ class JSONDatabase {
           siret: '12345678900011',
           legal_form: 'SARL',
           vat_number: 'FR123456789',
+          vat_rate: 20,
           rcs_number: 'Paris B 123456789',
           created_at: new Date().toISOString(),
           updated_at: new Date().toISOString()
@@ -191,6 +194,7 @@ class JSONDatabase {
       siret: data.siret || '',
       legal_form: data.legal_form || '',
       vat_number: data.vat_number || '',
+      vat_rate: typeof data.vat_rate !== 'undefined' ? parseFloat(data.vat_rate) : 0,
       rcs_number: data.rcs_number || ''
     };
 

--- a/backend/server.js
+++ b/backend/server.js
@@ -127,6 +127,7 @@ app.post('/api/factures', (req, res) => {
       siret = '',
       legal_form = '',
       vat_number = '',
+      vat_rate = 0,
       rcs_number = ''
     } = req.body;
 
@@ -161,6 +162,7 @@ app.post('/api/factures', (req, res) => {
       siret,
       legal_form,
       vat_number,
+      vat_rate,
       rcs_number
     };
 
@@ -197,6 +199,7 @@ app.put('/api/factures/:id', (req, res) => {
       siret = '',
       legal_form = '',
       vat_number = '',
+      vat_rate = 0,
       rcs_number = ''
     } = req.body;
 
@@ -228,6 +231,7 @@ app.put('/api/factures/:id', (req, res) => {
       siret,
       legal_form,
       vat_number,
+      vat_rate,
       rcs_number
     };
 

--- a/backend/services/pdfService.js
+++ b/backend/services/pdfService.js
@@ -63,11 +63,12 @@ function buildFacturePDF(facture, outPath) {
 
     let totalHT = 0;
     let totalTVA = 0;
+    const tauxTVA = parseFloat(facture.vat_rate || 0);
 
     (facture.lignes || []).forEach(ligne => {
       const qte = parseFloat(ligne.quantite) || 0;
       const pu = parseFloat(ligne.prix_unitaire) || 0;
-      const tva = parseFloat(ligne.tva || 0);
+      const tva = tauxTVA || parseFloat(ligne.tva || 0);
       const ht = qte * pu;
       const tvaMontant = ht * (tva / 100);
       const ttc = ht + tvaMontant;
@@ -90,7 +91,7 @@ function buildFacturePDF(facture, outPath) {
     doc.moveTo(350, y).lineTo(550, y).stroke();
     y += 5;
     doc.text(`Total HT : ${totalHT.toFixed(2)} €`, 350, (y += 15));
-    doc.text(`TVA : ${totalTVA.toFixed(2)} €`, 350, (y += 15));
+    doc.text(`TVA (${tauxTVA}% ) : ${totalTVA.toFixed(2)} €`, 350, (y += 15));
     doc.text(`Total TTC : ${totalTTC.toFixed(2)} €`, 350, (y += 15));
 
     // Conditions de paiement

--- a/frontend/src/pages/CreerFacture.tsx
+++ b/frontend/src/pages/CreerFacture.tsx
@@ -27,6 +27,7 @@ export default function CreerFacture() {
   const [siret, setSiret] = useState('');
   const [legalForm, setLegalForm] = useState('');
   const [vatNumber, setVatNumber] = useState('');
+  const [vatRate, setVatRate] = useState(20);
   const [rcsNumber, setRcsNumber] = useState('');
   const [lignes, setLignes] = useState<LigneFacture[]>([
     { description: '', quantite: 1, prix_unitaire: 0 }
@@ -141,6 +142,7 @@ export default function CreerFacture() {
           siret: siret.trim(),
           legal_form: legalForm.trim(),
           vat_number: vatNumber.trim(),
+          vat_rate: vatRate,
           rcs_number: rcsNumber.trim(),
           lignes: lignesValides
         }),
@@ -374,7 +376,7 @@ export default function CreerFacture() {
             )}
 
             <div className="space-y-4">
-              {lignes.map((ligne, index) => (
+            {lignes.map((ligne, index) => (
                 <div key={index} className="grid grid-cols-1 md:grid-cols-12 gap-4 p-4 bg-gray-50 rounded-lg">
                   <div className="md:col-span-5">
                     <label className="block text-sm font-medium text-gray-700 mb-1">
@@ -444,8 +446,22 @@ export default function CreerFacture() {
                     </button>
                   </div>
                 </div>
-              ))}
-            </div>
+            ))}
+          </div>
+
+          <div className="mt-4">
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Taux de TVA (%)
+            </label>
+            <input
+              type="number"
+              min="0"
+              step="0.01"
+              value={vatRate}
+              onChange={(e) => setVatRate(parseFloat(e.target.value) || 0)}
+              className="w-32 px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
+            />
+          </div>
 
             {/* Récapitulatif */}
             <div className="mt-6 p-4 bg-indigo-50 rounded-lg">

--- a/frontend/src/pages/DetailFacture.tsx
+++ b/frontend/src/pages/DetailFacture.tsx
@@ -23,6 +23,7 @@ interface Facture {
   siret?: string;
   legal_form?: string;
   vat_number?: string;
+  vat_rate?: number;
   rcs_number?: string;
   lignes: LigneFacture[];
 }
@@ -340,6 +341,12 @@ export default function DetailFacture() {
                 <div>
                   <p className="text-sm text-gray-500 mb-1">N° TVA</p>
                   <p className="font-semibold text-gray-900">{facture.vat_number}</p>
+                </div>
+              )}
+              {typeof facture.vat_rate !== 'undefined' && (
+                <div>
+                  <p className="text-sm text-gray-500 mb-1">Taux de TVA</p>
+                  <p className="font-semibold text-gray-900">{facture.vat_rate}%</p>
                 </div>
               )}
               {facture.rcs_number && (

--- a/frontend/src/pages/ModifierFacture.tsx
+++ b/frontend/src/pages/ModifierFacture.tsx
@@ -24,6 +24,7 @@ interface Facture {
   siret?: string;
   legal_form?: string;
   vat_number?: string;
+  vat_rate?: number;
   rcs_number?: string;
   lignes: Array<{
     id: number;
@@ -51,6 +52,7 @@ export default function ModifierFacture() {
   const [siret, setSiret] = useState('');
   const [legalForm, setLegalForm] = useState('');
   const [vatNumber, setVatNumber] = useState('');
+  const [vatRate, setVatRate] = useState(20);
   const [rcsNumber, setRcsNumber] = useState('');
   const [lignes, setLignes] = useState<LigneFacture[]>([
     { description: '', quantite: 1, prix_unitaire: 0 }
@@ -87,6 +89,7 @@ export default function ModifierFacture() {
       setSiret(facture.siret || '');
       setLegalForm(facture.legal_form || '');
       setVatNumber(facture.vat_number || '');
+      setVatRate(facture.vat_rate ?? 20);
       setRcsNumber(facture.rcs_number || '');
       
       // Convertir les lignes au format du formulaire
@@ -209,6 +212,7 @@ export default function ModifierFacture() {
           siret: siret.trim(),
           legal_form: legalForm.trim(),
           vat_number: vatNumber.trim(),
+          vat_rate: vatRate,
           rcs_number: rcsNumber.trim(),
           lignes: lignesValides
         }),
@@ -412,6 +416,17 @@ export default function ModifierFacture() {
                 type="text"
                 value={vatNumber}
                 onChange={(e) => setVatNumber(e.target.value)}
+                className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-2">Taux de TVA (%)</label>
+              <input
+                type="number"
+                min="0"
+                step="0.01"
+                value={vatRate}
+                onChange={(e) => setVatRate(parseFloat(e.target.value) || 0)}
                 className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
               />
             </div>


### PR DESCRIPTION
## Summary
- capture VAT rate on invoice creation and edition
- store vat_rate in backend and sample data
- include VAT rate when generating PDF totals
- display VAT rate in invoice details

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685620415b14832fab6878e30e299290