### PR TITLE
Add sorting for invoices list

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -52,12 +52,45 @@ const generateInvoiceNumber = () => {
 // GET /api/factures - Liste toutes les factures avec pagination et recherche
 app.get('/api/factures', (req, res) => {
   try {
-    const { page = 1, limit = 10, search = '', dateDebut = '', dateFin = '', status = '' } = req.query;
+    const {
+      page = 1,
+      limit = 10,
+      search = '',
+      dateDebut = '',
+      dateFin = '',
+      status = '',
+      sortBy = 'date',
+      order = 'desc'
+    } = req.query;
     const offset = (page - 1) * limit;
 
     const filters = { search, dateDebut, dateFin };
     if (status) filters.status = status;
     const allFactures = db.getFactures(filters);
+
+    // Tri
+    const sortFieldMap = {
+      nom: 'nom_client',
+      entreprise: 'nom_entreprise',
+      date: 'date_facture'
+    };
+    const sortField = sortFieldMap[sortBy] || 'date_facture';
+    const sortOrder = order === 'asc' ? 1 : -1;
+
+    allFactures.sort((a, b) => {
+      const aVal =
+        sortField === 'date_facture'
+          ? new Date(a[sortField])
+          : (a[sortField] || '').toString().toLowerCase();
+      const bVal =
+        sortField === 'date_facture'
+          ? new Date(b[sortField])
+          : (b[sortField] || '').toString().toLowerCase();
+      if (aVal < bVal) return -1 * sortOrder;
+      if (aVal > bVal) return 1 * sortOrder;
+      return 0;
+    });
+
     const total = allFactures.length;
     
     // Pagination

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -14,7 +14,7 @@ export default function Sidebar() {
         </NavLink>
         <NavLink to="/factures" className="flex items-center space-x-2 hover:text-primary">
           <FileText className="h-5 w-5" />
-          <span>Voir les factures</span>
+          <span>Toutes les factures</span>
         </NavLink>
         <NavLink to="/factures/nouvelle" className="flex items-center space-x-2 hover:text-primary">
           <PlusCircle className="h-5 w-5" />

--- a/frontend/src/pages/Accueil.tsx
+++ b/frontend/src/pages/Accueil.tsx
@@ -37,7 +37,7 @@ export default function Accueil() {
 
         {/* Action Cards */}
         <div className="grid grid-cols-1 md:grid-cols-2 gap-8 mb-16">
-          {/* Voir les factures */}
+          {/* Toutes les factures */}
           <Link
             to="/factures"
             className="group relative bg-gradient-to-br from-[var(--gradient-start)] via-[var(--gradient-mid)] to-[var(--gradient-end)] text-white rounded-2xl p-8 shadow-lg hover:shadow-xl transition-all duration-300"
@@ -46,7 +46,7 @@ export default function Accueil() {
               <FileText className="h-8 w-8 text-indigo-600" />
             </div>
             <h3 className="text-2xl font-bold text-gray-900 mb-3">
-              Voir les factures
+              Toutes les factures
             </h3>
             <p className="text-gray-600 mb-4">
               Consultez, recherchez et gérez toutes vos factures existantes. 

--- a/frontend/src/pages/ListeFactures.tsx
+++ b/frontend/src/pages/ListeFactures.tsx
@@ -39,6 +39,8 @@ export default function ListeFactures() {
   const [dateDebut, setDateDebut] = useState('');
   const [dateFin, setDateFin] = useState('');
   const [statusFilter, setStatusFilter] = useState('');
+  const [sortField, setSortField] = useState('date');
+  const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('desc');
 
   const chargerFactures = useCallback(async () => {
     try {
@@ -49,7 +51,9 @@ export default function ListeFactures() {
         search: recherche,
         dateDebut,
         dateFin,
-        status: statusFilter
+        status: statusFilter,
+        sortBy: sortField,
+        order: sortOrder
       });
 
       const response = await fetch(`http://localhost:3001/api/factures?${params}`);
@@ -65,7 +69,7 @@ export default function ListeFactures() {
     } finally {
       setLoading(false);
     }
-  }, [pagination.page, pagination.limit, recherche, dateDebut, dateFin, statusFilter]);
+  }, [pagination.page, pagination.limit, recherche, dateDebut, dateFin, statusFilter, sortField, sortOrder]);
 
   useEffect(() => {
     chargerFactures();
@@ -219,6 +223,29 @@ export default function ListeFactures() {
               <option value="">Tous</option>
               <option value="unpaid">Non payées</option>
               <option value="paid">Payées</option>
+            </select>
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-2">Trier par</label>
+            <select
+              value={sortField}
+              onChange={(e) => setSortField(e.target.value)}
+              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
+            >
+              <option value="date">Date</option>
+              <option value="nom">Nom</option>
+              <option value="entreprise">Entreprise</option>
+            </select>
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-2">Ordre</label>
+            <select
+              value={sortOrder}
+              onChange={(e) => setSortOrder(e.target.value as 'asc' | 'desc')}
+              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
+            >
+              <option value="asc">Croissant</option>
+              <option value="desc">Décroissant</option>
             </select>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- show "Toutes les factures" link in sidebar and home page
- support sorting invoices by name, company or date via API
- add sort fields and dropdowns in invoices list page

## Testing
- `pnpm run build` in `frontend`
- `pnpm test` in `backend`

------
https://chatgpt.com/codex/tasks/task_e_685625dfe264832faae29cccd8755084