### PR TITLE
Centralize API URL in helper

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,0 +1,1 @@
+export const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:3001/api';

--- a/frontend/src/pages/CreerFacture.tsx
+++ b/frontend/src/pages/CreerFacture.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { ArrowLeft, Plus, Trash2, Save, Calculator } from 'lucide-react';
+import { API_URL } from '@/lib/api';
 
 interface LigneFacture {
   description: string;
@@ -124,7 +125,7 @@ export default function CreerFacture() {
         ligne.description.trim() && ligne.quantite > 0 && ligne.prix_unitaire >= 0
       );
 
-      const response = await fetch('http://localhost:3001/api/factures', {
+      const response = await fetch(`${API_URL}/factures`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/frontend/src/pages/DetailFacture.tsx
+++ b/frontend/src/pages/DetailFacture.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback } from 'react';
 import { Link, useParams, useNavigate } from 'react-router-dom';
 import { ArrowLeft, Edit, Download, Trash2, FileText, User, Calendar, Euro } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import { API_URL } from '@/lib/api';
 
 interface Facture {
   id: number;
@@ -39,7 +40,6 @@ interface LigneFacture {
 export default function DetailFacture() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
-  const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:3001/api';
   const [facture, setFacture] = useState<Facture | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -47,7 +47,7 @@ export default function DetailFacture() {
   const chargerFacture = useCallback(async () => {
     try {
       setLoading(true);
-      const response = await fetch(`http://localhost:3001/api/factures/${id}`);
+      const response = await fetch(`${API_URL}/factures/${id}`);
       
       if (!response.ok) {
         if (response.status === 404) {
@@ -79,7 +79,7 @@ export default function DetailFacture() {
     }
 
     try {
-      const response = await fetch(`http://localhost:3001/api/factures/${id}`, {
+      const response = await fetch(`${API_URL}/factures/${id}`, {
         method: 'DELETE'
       });
 

--- a/frontend/src/pages/ListeFactures.tsx
+++ b/frontend/src/pages/ListeFactures.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import { Search, Filter, FileText, Plus, Eye, Edit, Trash2, Download, ArrowLeft, Calendar } from 'lucide-react';
+import { API_URL } from '@/lib/api';
 
 interface Facture {
   id: number;
@@ -56,7 +57,7 @@ export default function ListeFactures() {
         order: sortOrder
       });
 
-      const response = await fetch(`http://localhost:3001/api/factures?${params}`);
+      const response = await fetch(`${API_URL}/factures?${params}`);
       if (!response.ok) {
         throw new Error('Erreur lors du chargement des factures');
       }
@@ -87,7 +88,7 @@ export default function ListeFactures() {
     }
 
     try {
-      const response = await fetch(`http://localhost:3001/api/factures/${id}`, {
+      const response = await fetch(`${API_URL}/factures/${id}`, {
         method: 'DELETE'
       });
 
@@ -104,7 +105,7 @@ export default function ListeFactures() {
 
   const telechargerPDF = async (id: number, numeroFacture: string) => {
     try {
-      const response = await fetch(`http://localhost:3001/api/factures/${id}/pdf`);
+      const response = await fetch(`${API_URL}/factures/${id}/pdf`);
       if (!response.ok) {
         throw new Error('Erreur lors de la génération du PDF');
       }

--- a/frontend/src/pages/ModifierFacture.tsx
+++ b/frontend/src/pages/ModifierFacture.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { Link, useParams, useNavigate } from 'react-router-dom';
 import { ArrowLeft, Plus, Trash2, Save, Calculator } from 'lucide-react';
+import { API_URL } from '@/lib/api';
 
 interface LigneFacture {
   description: string;
@@ -67,7 +68,7 @@ export default function ModifierFacture() {
   const chargerFacture = useCallback(async () => {
     try {
       setLoading(true);
-      const response = await fetch(`http://localhost:3001/api/factures/${id}`);
+      const response = await fetch(`${API_URL}/factures/${id}`);
       
       if (!response.ok) {
         throw new Error('Facture non trouvée');
@@ -194,7 +195,7 @@ export default function ModifierFacture() {
         ligne.description.trim() && ligne.quantite > 0 && ligne.prix_unitaire >= 0
       );
 
-      const response = await fetch(`http://localhost:3001/api/factures/${id}`, {
+      const response = await fetch(`${API_URL}/factures/${id}`, {
         method: 'PUT',
         headers: {
           'Content-Type': 'application/json',


### PR DESCRIPTION
## Summary
- add `src/lib/api.ts` helper with `API_URL`
- refactor invoice pages to use the shared API URL

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6856297ffe94832f9a13090a40231549