### PR TITLE
Add VAT rate field to migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Un script est fourni pour ajouter les nouveaux champs légaux aux anciennes fact
 cd backend
 node database/migrations/002-add-legal-fields.js
 ```
+Ce script renseigne également le champ `vat_rate` (taux de TVA) à `0` pour les factures qui n'en possèdent pas.
 
 ## 📁 Structure du projet
 

--- a/backend/database/data/factures.json
+++ b/backend/database/data/factures.json
@@ -1,5 +1,14 @@
 [
   {
+    "title": "Facture #4",
+    "status": "unpaid",
+    "logo_path": "",
+    "siren": "",
+    "siret": "",
+    "legal_form": "",
+    "vat_number": "",
+    "rcs_number": "",
+    "vat_rate": 20,
     "id": 4,
     "numero_facture": "FACT-2025-595381",
     "nom_client": "Alan Emmanuel Emile",
@@ -8,7 +17,6 @@
     "adresse": "2 rue de Ludres, Vandœuvre-lès-Nancy \n54500, France",
     "date_facture": "2025-06-20",
     "montant_total": 100,
-    "vat_rate": 20,
     "created_at": "2025-06-20T18:53:15.382Z",
     "updated_at": "2025-06-20T18:53:15.382Z"
   }

--- a/backend/database/migrations/002-add-legal-fields.js
+++ b/backend/database/migrations/002-add-legal-fields.js
@@ -13,6 +13,7 @@ const updated = factures.map(f => ({
   legal_form: f.legal_form || '',
   vat_number: f.vat_number || '',
   rcs_number: f.rcs_number || '',
+  vat_rate: typeof f.vat_rate !== 'undefined' ? f.vat_rate : 0,
   ...f
 }))
 


### PR DESCRIPTION
## Summary
- update migration script to include `vat_rate` field with default 0
- run migration to update example JSON data
- document migration behavior regarding VAT rate

## Testing
- `pnpm install` in backend
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6856298d62f0832fb42278f536b98c56