### PR TITLE
Add line item validation

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -166,11 +166,29 @@ app.post('/api/factures', (req, res) => {
 
     // Validation
     if (!nom_client || !date_facture || !lignes.length) {
-      return res.status(400).json({ 
+      return res.status(400).json({
         error: 'Données manquantes',
-        details: 'Le nom du client, la date et au moins une ligne sont requis' 
+        details: 'Le nom du client, la date et au moins une ligne sont requis'
       });
     }
+
+    for (let i = 0; i < lignes.length; i++) {
+      const q = parseFloat(lignes[i].quantite);
+      const pu = parseFloat(lignes[i].prix_unitaire);
+      if (!(q > 0)) {
+        return res.status(400).json({
+          error: 'Quantité invalide',
+          details: `La quantité de la ligne ${i + 1} doit être supérieure à 0`
+        });
+      }
+      if (!(pu >= 0)) {
+        return res.status(400).json({
+          error: 'Prix unitaire invalide',
+          details: `Le prix unitaire de la ligne ${i + 1} doit être positif`
+        });
+      }
+    }
+
 
     // Calculer le montant total
     const montant_total = lignes.reduce((total, ligne) => {
@@ -242,6 +260,22 @@ app.put('/api/factures/:id', (req, res) => {
         error: 'Données manquantes',
         details: 'Le nom du client, la date et au moins une ligne sont requis' 
       });
+    }
+    for (let i = 0; i < lignes.length; i++) {
+      const q = parseFloat(lignes[i].quantite);
+      const pu = parseFloat(lignes[i].prix_unitaire);
+      if (!(q > 0)) {
+        return res.status(400).json({
+          error: 'Quantité invalide',
+          details: `La quantité de la ligne ${i + 1} doit être supérieure à 0`
+        });
+      }
+      if (!(pu >= 0)) {
+        return res.status(400).json({
+          error: 'Prix unitaire invalide',
+          details: `Le prix unitaire de la ligne ${i + 1} doit être positif`
+        });
+      }
     }
 
     // Calculer le montant total

--- a/backend/tests/validation.test.js
+++ b/backend/tests/validation.test.js
@@ -1,0 +1,59 @@
+const request = require('supertest');
+const app = require('../server');
+
+describe('Validation of lignes', () => {
+  test('POST rejects non positive quantity', async () => {
+    const res = await request(app)
+      .post('/api/factures')
+      .send({
+        nom_client: 'Client',
+        date_facture: '2024-01-01',
+        lignes: [
+          { description: 'Item', quantite: 0, prix_unitaire: 10 }
+        ]
+      });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Quantité invalide');
+  });
+
+  test('POST rejects negative unit price', async () => {
+    const res = await request(app)
+      .post('/api/factures')
+      .send({
+        nom_client: 'Client',
+        date_facture: '2024-01-01',
+        lignes: [
+          { description: 'Item', quantite: 1, prix_unitaire: -5 }
+        ]
+      });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Prix unitaire invalide');
+  });
+
+  test('PUT rejects invalid values', async () => {
+    // create a valid facture first
+    const createRes = await request(app)
+      .post('/api/factures')
+      .send({
+        nom_client: 'Client',
+        date_facture: '2024-01-01',
+        lignes: [
+          { description: 'Item', quantite: 1, prix_unitaire: 10 }
+        ]
+      });
+    expect(createRes.status).toBe(201);
+    const id = createRes.body.id;
+
+    const updateRes = await request(app)
+      .put(`/api/factures/${id}`)
+      .send({
+        nom_client: 'Client',
+        date_facture: '2024-01-01',
+        lignes: [
+          { description: 'Item', quantite: -1, prix_unitaire: 10 }
+        ]
+      });
+    expect(updateRes.status).toBe(400);
+    expect(updateRes.body.error).toBe('Quantité invalide');
+  });
+});


### PR DESCRIPTION
## Summary
- validate quantity and unit price for line items in POST and PUT
- test rejection of negative or zero values

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685629928d68832fa9c66ff7234cd67c