### PR TITLE
Fix VAT rate handling

### DIFF
--- a/backend/database/storage.js
+++ b/backend/database/storage.js
@@ -194,7 +194,10 @@ class JSONDatabase {
       siret: data.siret || '',
       legal_form: data.legal_form || '',
       vat_number: data.vat_number || '',
-      vat_rate: typeof data.vat_rate !== 'undefined' ? parseFloat(data.vat_rate) : 0,
+      vat_rate:
+        data.vat_rate !== undefined && data.vat_rate !== ''
+          ? parseFloat(data.vat_rate)
+          : 0,
       rcs_number: data.rcs_number || ''
     };
 

--- a/backend/server.js
+++ b/backend/server.js
@@ -163,6 +163,9 @@ app.post('/api/factures', (req, res) => {
       vat_rate = 0,
       rcs_number = ''
     } = req.body;
+    const parsedVatRate =
+      vat_rate !== undefined && vat_rate !== '' ? parseFloat(vat_rate) : 0;
+
 
     // Validation
     if (!nom_client || !date_facture || !lignes.length) {
@@ -213,7 +216,7 @@ app.post('/api/factures', (req, res) => {
       siret,
       legal_form,
       vat_number,
-      vat_rate,
+      vat_rate: parsedVatRate,
       rcs_number
     };
 
@@ -253,6 +256,9 @@ app.put('/api/factures/:id', (req, res) => {
       vat_rate = 0,
       rcs_number = ''
     } = req.body;
+    const parsedVatRate =
+      vat_rate !== undefined && vat_rate !== '' ? parseFloat(vat_rate) : 0;
+
 
     // Validation
     if (!nom_client || !date_facture || !lignes.length) {
@@ -298,7 +304,7 @@ app.put('/api/factures/:id', (req, res) => {
       siret,
       legal_form,
       vat_number,
-      vat_rate,
+      vat_rate: parsedVatRate,
       rcs_number
     };
 


### PR DESCRIPTION
## Summary
- normalize `vat_rate` values before persisting
- parse VAT rate in create/update routes

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68562b0a1bdc832f9b8568b573a5e719