### PR TITLE
Fix theme toggle with persistent provider

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5,9 +5,17 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Created by Young Slim</title>
+  <script>
+    (function () {
+      const stored = localStorage.getItem('theme');
+      const systemDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+      const theme = !stored || stored === 'system' ? (systemDark ? 'dark' : 'light') : stored;
+      document.documentElement.classList.add(theme);
+    })();
+  </script>
 </head>
 
-<body>
+<body class="app-fade">
   <div id="root"></div>
   <script type="module" src="/src/main.tsx"></script>
 </body>

--- a/frontend/src/context/ThemeContext.tsx
+++ b/frontend/src/context/ThemeContext.tsx
@@ -15,28 +15,35 @@ interface ThemeContextValue {
 const ThemeContext = createContext<ThemeContextValue | undefined>(undefined)
 
 export const ThemeProvider = ({ children }: { children: React.ReactNode }) => {
-  const [theme, setTheme] = useState<Theme>('system')
+  const getSystem = () =>
+    window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+  const [theme, setTheme] = useState<Theme>(() => {
+    if (typeof window === 'undefined') return 'system'
+    const stored = localStorage.getItem('theme') as Theme | null
+    return stored ?? 'system'
+  })
 
   useEffect(() => {
     const root = document.documentElement
     const applyTheme = () => {
-      root.classList.remove('theme-sunset', 'theme-light', 'theme-dark', 'dark')
+      root.classList.remove('light', 'dark', 'sunset')
 
       if (theme === 'sunset') {
-        root.classList.add('theme-sunset')
+        root.classList.add('sunset')
         return
       }
 
-      const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches
+      const prefersDark = getSystem() === 'dark'
 
       if (theme === 'dark' || (theme === 'system' && prefersDark)) {
-        root.classList.add('theme-dark', 'dark')
+        root.classList.add('dark')
       } else {
-        root.classList.add('theme-light')
+        root.classList.add('light')
       }
     }
 
     applyTheme()
+    localStorage.setItem('theme', theme)
 
     if (theme === 'system') {
       const media = window.matchMedia('(prefers-color-scheme: dark)')

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -2,6 +2,7 @@
 @tailwind components;
 @tailwind utilities;
 
+
 @layer base {
   :root {
     --radius: 0.5rem;
@@ -12,13 +13,17 @@
     --sidebar-accent: 240 4.8% 95.9%;
     --sidebar-accent-foreground: 240 5.9% 10%;
     --sidebar-border: 220 13% 91%;
-    --sidebar-ring: 217.2 91.2% 59.8%
+    --sidebar-ring: 217.2 91.2% 59.8%;
     --gradient-start: #f97316;
     --gradient-mid: #ec4899;
     --gradient-end: #8b5cf6;
   }
 
-  .dark {
+  html.light {
+    --background: white;
+  }
+
+  html.dark {
     --sidebar-background: 240 5.9% 10%;
     --sidebar-foreground: 240 4.8% 95.9%;
     --sidebar-primary: 224.3 76.3% 48%;
@@ -26,30 +31,45 @@
     --sidebar-accent: 240 3.7% 15.9%;
     --sidebar-accent-foreground: 240 4.8% 95.9%;
     --sidebar-border: 240 3.7% 15.9%;
-    --sidebar-ring: 217.2 91.2% 59.8%
-  }
-
-  .theme-sunset {
-    --background: var(--gradient-start);
-  }
-  .theme-light {
-    --background: white;
-  }
-  .theme-dark {
+    --sidebar-ring: 217.2 91.2% 59.8%;
     --background: #1f2937;
     --foreground: #f9fafb;
   }
+
+  html.sunset {
+    --background: var(--gradient-start);
+  }
 }
 
-body.theme-sunset {
+html,
+body {
+  transition: background-color 0.2s, color 0.2s;
+}
+
+html.sunset body {
   background-image: linear-gradient(to bottom, var(--gradient-start), var(--gradient-mid), var(--gradient-end));
 }
-body.theme-light {
+
+html.light body {
   background-color: white;
 }
-body.theme-dark {
+
+html.dark body {
   background-color: #1f2937;
   color: var(--foreground);
+}
+
+body.app-fade {
+  animation: fade-in 0.4s ease-in-out;
+}
+
+@keyframes fade-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
 }
 
 


### PR DESCRIPTION
## Summary
- load theme from `localStorage` and system preference
- store theme selection and toggle with a new context
- apply theme class before React mounts to avoid flash
- define css vars for `light` and `dark` themes with transitions
- animate app load

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_6856349a642c832f9a7887e1d53c8ee7