### PR TITLE
Improve frontend styling

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5,6 +5,12 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Created by Young Slim</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link
+    href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap"
+    rel="stylesheet"
+  />
   <script>
     (function () {
       const stored = localStorage.getItem('theme');

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -44,6 +44,8 @@
 html,
 body {
   transition: background-color 0.2s, color 0.2s;
+  font-family: 'Inter', sans-serif;
+  @apply antialiased;
 }
 
 html.sunset body {

--- a/frontend/src/pages/Accueil.tsx
+++ b/frontend/src/pages/Accueil.tsx
@@ -5,7 +5,9 @@ export default function Accueil() {
   return (
     <div className="min-h-screen">
       {/* Header */}
-      <header className="bg-white shadow-sm border-b border-gray-200">
+      <header
+        className="bg-gradient-to-r from-[var(--gradient-start)] via-[var(--gradient-mid)] to-[var(--gradient-end)] text-white shadow-sm border-b border-gray-200"
+      >
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex justify-between items-center h-16">
             <div className="flex items-center">

--- a/frontend/src/pages/CreerFacture.tsx
+++ b/frontend/src/pages/CreerFacture.tsx
@@ -167,7 +167,9 @@ export default function CreerFacture() {
   return (
     <div className="min-h-screen">
       {/* Header */}
-      <header className="bg-white shadow-sm border-b border-gray-200">
+      <header
+        className="bg-gradient-to-r from-[var(--gradient-start)] via-[var(--gradient-mid)] to-[var(--gradient-end)] text-white shadow-sm border-b border-gray-200"
+      >
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex justify-between items-center h-16">
             <div className="flex items-center">

--- a/frontend/src/pages/DetailFacture.tsx
+++ b/frontend/src/pages/DetailFacture.tsx
@@ -163,7 +163,9 @@ export default function DetailFacture() {
   return (
     <div className="min-h-screen">
       {/* Header */}
-      <header className="bg-white shadow-sm border-b border-gray-200">
+      <header
+        className="bg-gradient-to-r from-[var(--gradient-start)] via-[var(--gradient-mid)] to-[var(--gradient-end)] text-white shadow-sm border-b border-gray-200"
+      >
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex justify-between items-center h-16">
             <div className="flex items-center">

--- a/frontend/src/pages/ListeFactures.tsx
+++ b/frontend/src/pages/ListeFactures.tsx
@@ -154,7 +154,9 @@ export default function ListeFactures() {
   return (
     <div className="min-h-screen">
       {/* Header */}
-      <header className="bg-white shadow-sm border-b border-gray-200">
+      <header
+        className="bg-gradient-to-r from-[var(--gradient-start)] via-[var(--gradient-mid)] to-[var(--gradient-end)] text-white shadow-sm border-b border-gray-200"
+      >
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex justify-between items-center h-16">
             <div className="flex items-center">

--- a/frontend/src/pages/ModifierFacture.tsx
+++ b/frontend/src/pages/ModifierFacture.tsx
@@ -247,7 +247,9 @@ export default function ModifierFacture() {
   return (
     <div className="min-h-screen">
       {/* Header */}
-      <header className="bg-white shadow-sm border-b border-gray-200">
+      <header
+        className="bg-gradient-to-r from-[var(--gradient-start)] via-[var(--gradient-mid)] to-[var(--gradient-end)] text-white shadow-sm border-b border-gray-200"
+      >
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex justify-between items-center h-16">
             <div className="flex items-center">


### PR DESCRIPTION
## Summary
- load the Inter webfont
- make pages use a gradient header
- apply Inter font globally

## Testing
- `pnpm install` in `backend`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68563639b95c832f8390e464fb02f8fd