### PR TITLE
Add helper for VAT from TTC

### DIFF
--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -4,3 +4,13 @@ import { twMerge } from 'tailwind-merge';
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
+
+/**
+ * Calcule le prix HT et le montant de TVA à partir d'un montant TTC.
+ * Les résultats sont arrondis au centime comme en comptabilité.
+ */
+export function fromTTC(ttc: number, taux: number) {
+  const ht = parseFloat((ttc / (1 + taux / 100)).toFixed(2));
+  const tva = parseFloat((ttc - ht).toFixed(2));
+  return { ht, tva };
+}

--- a/frontend/src/pages/DetailFacture.tsx
+++ b/frontend/src/pages/DetailFacture.tsx
@@ -3,6 +3,7 @@ import { Link, useParams, useNavigate } from 'react-router-dom';
 import { ArrowLeft, Edit, Download, Trash2, FileText, User, Calendar, Euro } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { API_URL } from '@/lib/api';
+import { fromTTC } from '@/lib/utils';
 
 interface Facture {
   id: number;
@@ -163,6 +164,7 @@ export default function DetailFacture() {
   const totalHT = facture.montant_total;
   const tauxTVA = facture.vat_rate ?? 0;
   const totalTTC = totalHT * (1 + tauxTVA / 100);
+  const { tva: montantTVA } = fromTTC(totalTTC, tauxTVA);
 
   return (
     <div className="min-h-screen">
@@ -417,6 +419,14 @@ export default function DetailFacture() {
                     </td>
                     <td className="px-6 py-4 text-right">
                       <p className="text-lg font-bold text-indigo-600">{formatEuro(totalHT)}</p>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td colSpan={3} className="px-6 py-4 text-right">
+                      <p className="text-lg font-bold text-gray-900">TVA {tauxTVA}%</p>
+                    </td>
+                    <td className="px-6 py-4 text-right">
+                      <p className="text-lg font-bold text-indigo-600">{formatEuro(montantTVA)}</p>
                     </td>
                   </tr>
                   <tr>


### PR DESCRIPTION
## Summary
- compute VAT amount from a TTC value
- use helper when displaying invoice totals

## Testing
- `pnpm lint`
- `pnpm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856386cd118832f8fca00821cae3eca