### PR TITLE
perf: reuse Intl formatters

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -17,18 +17,20 @@ app.use(bodyParser.urlencoded({ extended: true }));
 // Base de données JSON
 const db = new JSONDatabase();
 
-// Utilitaire pour formater les nombres en français
-const formatEuro = (amount) => {
-  return new Intl.NumberFormat('fr-FR', {
-    style: 'currency',
-    currency: 'EUR'
-  }).format(amount);
-};
+// Formatters réutilisables pour éviter de recréer les objets à chaque appel
+const euroFormatter = new Intl.NumberFormat('fr-FR', {
+  style: 'currency',
+  currency: 'EUR'
+});
+const dateFormatter = new Intl.DateTimeFormat('fr-FR');
+
+// Utilitaire pour formater les montants en euros
+const formatEuro = (amount) => euroFormatter.format(amount);
 
 // Utilitaire pour formater les dates en français
 const formatDateFR = (dateString) => {
   const date = new Date(dateString);
-  return date.toLocaleDateString('fr-FR');
+  return dateFormatter.format(date);
 };
 
 // Générer un numéro de facture automatique


### PR DESCRIPTION
## Summary
- reuse Intl.NumberFormat and Intl.DateTimeFormat instances for formatting

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68563b206a0c832fae87706e35d5c8a5