### PR TITLE
Add macOS install and launcher scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,14 @@ Exécutez le script `install.sh` à la racine du projet. Il détecte automatique
 ./install.sh
 ```
 
+### Installation macOS (Apple Silicon)
+
+Un script spécifique `install_macos.sh` simplifie l'installation sur macOS avec processeur Apple Silicon. Il vérifie que Homebrew, Node.js et pnpm sont présents puis lance `install.sh` :
+
+```bash
+./install_macos.sh
+```
+
 ### Installation manuelle
 
 1. **Cloner ou télécharger le projet**
@@ -81,6 +89,14 @@ Exécutez le script `install.sh` à la racine du projet. Il détecte automatique
   pnpm run dev
   ```
   L'application est accessible sur http://localhost:5173
+
+#### Lancement rapide sur macOS
+
+Le script `launch_safari.sh` démarre le backend et le frontend puis ouvre automatiquement Safari sur l'URL de l'application :
+
+```bash
+./launch_safari.sh
+```
 
 ### Migration de la base de données
 Un script est fourni pour ajouter les nouveaux champs légaux aux anciennes factures :

--- a/install_macos.sh
+++ b/install_macos.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -e
+
+# Installation script for macOS Apple Silicon
+if [[ "$(uname)" != "Darwin" ]]; then
+  echo "Ce script est destiné à macOS." >&2
+  exit 1
+fi
+
+if [[ "$(uname -m)" != "arm64" ]]; then
+  echo "\033[33m[installer] Ce script est optimisé pour les Mac Apple Silicon (arm64)\033[0m"
+fi
+
+cd "$(dirname "$0")"
+
+if ! command -v brew >/dev/null 2>&1; then
+  echo "[installer] Homebrew n'est pas installé. Installez-le depuis https://brew.sh/ puis relancez ce script." >&2
+  exit 1
+fi
+
+if ! command -v node >/dev/null 2>&1; then
+  echo "[installer] Installation de Node.js via Homebrew..."
+  brew install node
+fi
+
+if ! command -v pnpm >/dev/null 2>&1; then
+  echo "[installer] Installation de pnpm..."
+  npm install -g pnpm
+fi
+
+# Execute generic install script
+./install.sh

--- a/launch_safari.sh
+++ b/launch_safari.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -e
+
+# Launcher script for macOS
+if [[ "$(uname)" != "Darwin" ]]; then
+  echo "Ce script est destiné à macOS." >&2
+  exit 1
+fi
+
+cd "$(dirname "$0")"
+
+PM=pnpm
+if ! command -v pnpm >/dev/null 2>&1; then
+  PM=npm
+fi
+
+# Start backend in background
+echo "[launcher] Démarrage du backend..."
+(cd backend && "$PM" start > ../backend.log 2>&1 &)
+BACK_PID=$!
+
+# Start frontend in background (dev server)
+echo "[launcher] Démarrage du frontend..."
+(cd frontend && "$PM" run dev > ../frontend.log 2>&1 &)
+FRONT_PID=$!
+
+sleep 3
+open -a Safari http://localhost:5173
+
+echo "[launcher] Safari ouvert sur http://localhost:5173"
+
+trap "kill $BACK_PID $FRONT_PID" SIGINT
+wait $FRONT_PID


### PR DESCRIPTION
## Summary
- add `install_macos.sh` for Apple Silicon
- add `launch_safari.sh` to start servers and open Safari
- update README with usage instructions

## Testing
- `pnpm install` and `pnpm test` in backend
- `pnpm install` and `pnpm test` in frontend

------
https://chatgpt.com/codex/tasks/task_e_6856d57ddc44832fb6c417048c0f8789