### PR TITLE
Enable invoice number editing

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -149,6 +149,7 @@ app.get('/api/factures/:id', (req, res) => {
 app.post('/api/factures', (req, res) => {
   try {
     const {
+      numero_facture: numero_facture_input = '',
       nom_client,
       nom_entreprise = '',
       telephone = '',
@@ -200,7 +201,7 @@ app.post('/api/factures', (req, res) => {
       return total + (parseFloat(ligne.quantite) * parseFloat(ligne.prix_unitaire));
     }, 0);
 
-    const numero_facture = generateInvoiceNumber();
+    const numero_facture = numero_facture_input.trim() || generateInvoiceNumber();
 
     const factureData = {
       numero_facture,
@@ -242,6 +243,7 @@ app.put('/api/factures/:id', (req, res) => {
   try {
     const { id } = req.params;
     const {
+      numero_facture: numero_facture_input = '',
       nom_client,
       nom_entreprise = '',
       telephone = '',
@@ -292,6 +294,7 @@ app.put('/api/factures/:id', (req, res) => {
     }, 0);
 
     const factureData = {
+      ...(numero_facture_input ? { numero_facture: numero_facture_input.trim() } : {}),
       nom_client: nom_client.trim(),
       nom_entreprise: nom_entreprise.trim(),
       telephone: telephone.trim(),

--- a/frontend/src/pages/CreerFacture.tsx
+++ b/frontend/src/pages/CreerFacture.tsx
@@ -24,6 +24,7 @@ export default function CreerFacture() {
   const [title, setTitle] = useState('');
   const [status, setStatus] = useState<'paid' | 'unpaid'>('unpaid');
   const [logoPath, setLogoPath] = useState('');
+  const [numeroFacture, setNumeroFacture] = useState('');
   const [siren, setSiren] = useState('');
   const [siret, setSiret] = useState('');
   const [legalForm, setLegalForm] = useState('');
@@ -131,6 +132,7 @@ export default function CreerFacture() {
           'Content-Type': 'application/json',
         },
         body: JSON.stringify({
+          numero_facture: numeroFacture.trim(),
           nom_client: nomClient.trim(),
           nom_entreprise: nomEntreprise.trim(),
           telephone: telephone.trim(),
@@ -277,6 +279,17 @@ export default function CreerFacture() {
         <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
           <h3 className="text-lg font-semibold text-gray-900 mb-6">Informations légales</h3>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-2">
+                Numéro de facture
+              </label>
+              <input
+                type="text"
+                value={numeroFacture}
+                onChange={(e) => setNumeroFacture(e.target.value)}
+                className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
+              />
+            </div>
             <div>
               <label className="block text-sm font-medium text-gray-700 mb-2">
                 Intitulé

--- a/frontend/src/pages/ModifierFacture.tsx
+++ b/frontend/src/pages/ModifierFacture.tsx
@@ -49,6 +49,7 @@ export default function ModifierFacture() {
   const [title, setTitle] = useState('');
   const [status, setStatus] = useState<'paid' | 'unpaid'>('unpaid');
   const [logoPath, setLogoPath] = useState('');
+  const [numeroFacture, setNumeroFacture] = useState('');
   const [siren, setSiren] = useState('');
   const [siret, setSiret] = useState('');
   const [legalForm, setLegalForm] = useState('');
@@ -86,6 +87,7 @@ export default function ModifierFacture() {
       setTitle(facture.title || '');
       setStatus(facture.status || 'unpaid');
       setLogoPath(facture.logo_path || '');
+      setNumeroFacture(facture.numero_facture || '');
       setSiren(facture.siren || '');
       setSiret(facture.siret || '');
       setLegalForm(facture.legal_form || '');
@@ -201,6 +203,7 @@ export default function ModifierFacture() {
           'Content-Type': 'application/json',
         },
         body: JSON.stringify({
+          numero_facture: numeroFacture.trim(),
           nom_client: nomClient.trim(),
           nom_entreprise: nomEntreprise.trim(),
           telephone: telephone.trim(),
@@ -357,6 +360,15 @@ export default function ModifierFacture() {
         <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
           <h3 className="text-lg font-semibold text-gray-900 mb-6">Informations légales</h3>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-2">Numéro de facture</label>
+              <input
+                type="text"
+                value={numeroFacture}
+                onChange={(e) => setNumeroFacture(e.target.value)}
+                className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
+              />
+            </div>
             <div>
               <label className="block text-sm font-medium text-gray-700 mb-2">Intitulé</label>
               <input


### PR DESCRIPTION
## Summary
- allow optional `numero_facture` when creating or updating invoices
- show invoice number field in create and edit forms

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_6856eb60bfa8832f8c024b190459ba56