### PR TITLE
Update system theme colors

### DIFF
--- a/frontend/src/components/ui/sonner.tsx
+++ b/frontend/src/components/ui/sonner.tsx
@@ -8,17 +8,12 @@ type ToasterProps = React.ComponentProps<typeof Sonner>
 const Toaster = ({ ...props }: ToasterProps) => {
   const { theme } = useTheme()
 
-  const systemPrefersDark =
-    typeof window !== "undefined" &&
-    window.matchMedia("(prefers-color-scheme: dark)").matches
   const toastTheme: ToasterProps["theme"] =
     theme === "sunset"
       ? "light"
       : theme === "dark"
         ? "dark"
-        : systemPrefersDark
-          ? "dark"
-          : "light"
+        : "light"
 
   return (
     <Sonner

--- a/frontend/src/context/ThemeContext.tsx
+++ b/frontend/src/context/ThemeContext.tsx
@@ -26,17 +26,17 @@ export const ThemeProvider = ({ children }: { children: React.ReactNode }) => {
   useEffect(() => {
     const root = document.documentElement
     const applyTheme = () => {
-      root.classList.remove('light', 'dark', 'sunset')
+      root.classList.remove('light', 'dark', 'sunset', 'system')
 
       if (theme === 'sunset') {
         root.classList.add('sunset')
         return
       }
 
-      const prefersDark = getSystem() === 'dark'
-
-      if (theme === 'dark' || (theme === 'system' && prefersDark)) {
+      if (theme === 'dark') {
         root.classList.add('dark')
+      } else if (theme === 'system') {
+        root.classList.add('system')
       } else {
         root.classList.add('light')
       }
@@ -45,11 +45,7 @@ export const ThemeProvider = ({ children }: { children: React.ReactNode }) => {
     applyTheme()
     localStorage.setItem('theme', theme)
 
-    if (theme === 'system') {
-      const media = window.matchMedia('(prefers-color-scheme: dark)')
-      media.addEventListener('change', applyTheme)
-      return () => media.removeEventListener('change', applyTheme)
-    }
+    // no system media listener
   }, [theme])
 
   const toggleTheme = () => {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -23,6 +23,11 @@
     --background: white;
   }
 
+  html.system {
+    --background: white;
+    --foreground: #1e3a8a;
+  }
+
   html.dark {
     --sidebar-background: 240 5.9% 10%;
     --sidebar-foreground: 240 4.8% 95.9%;
@@ -54,6 +59,11 @@ html.sunset body {
 
 html.light body {
   background-color: white;
+}
+
+html.system body {
+  background-color: white;
+  color: var(--foreground);
 }
 
 html.dark body {


### PR DESCRIPTION
## Summary
- create a dedicated `system` theme class with white background and blue text
- update theme switching logic to apply the new class
- adjust toast theming to treat `system` as light

## Testing
- `npm test` *(fails: jest not found)* for backend
- `npm test` *(fails: jest not found)* for frontend

------
https://chatgpt.com/codex/tasks/task_e_6856ec334a2c832fb881690c703a1ea5