### PR TITLE
Amélioration page d'accueil et carte API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+node_modules/
+frontend/node_modules/
+backend/node_modules/
+*.log
+
+# build outputs
+frontend/dist/
+backend/dist/

--- a/frontend/src/components/cards/ApiInfoCard.tsx
+++ b/frontend/src/components/cards/ApiInfoCard.tsx
@@ -1,0 +1,80 @@
+import { useEffect, useState } from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+import { API_URL } from '@/lib/api';
+
+interface Health {
+  status: string;
+  message: string;
+  timestamp: string;
+}
+
+export function ApiInfoCard() {
+  const [health, setHealth] = useState<Health | null>(null);
+  const [error, setError] = useState(false);
+
+  useEffect(() => {
+    const key = 'api-health-cache';
+    const cached = localStorage.getItem(key);
+    if (cached) {
+      try {
+        const parsed = JSON.parse(cached) as { data: Health; ts: number };
+        if (Date.now() - parsed.ts < 5 * 60 * 1000) {
+          setHealth(parsed.data);
+          return;
+        }
+      } catch {
+        /* ignore */
+      }
+    }
+    fetch(`${API_URL}/health`)
+      .then((r) => (r.ok ? r.json() : Promise.reject()))
+      .then((d: Health) => {
+        setHealth(d);
+        localStorage.setItem(key, JSON.stringify({ data: d, ts: Date.now() }));
+      })
+      .catch(() => setError(true));
+  }, []);
+
+  const endpoints = [
+    'GET /api/factures',
+    'GET /api/factures/:id',
+    'POST /api/factures',
+    'PUT /api/factures/:id',
+    'DELETE /api/factures/:id',
+    'GET /api/clients',
+    'POST /api/clients',
+    'GET /api/clients/:id',
+    'GET /api/health',
+    'GET /api/stats',
+  ];
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>API</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {health && !error ? (
+          <div className="space-y-2 text-sm">
+            <div>
+              <span className="font-medium">{health.message}</span>
+            </div>
+            <ul className="list-disc ml-4">
+              {endpoints.map((e) => (
+                <li key={e} className="font-mono">
+                  {e}
+                </li>
+              ))}
+            </ul>
+          </div>
+        ) : error ? (
+          <div className="text-red-500 text-sm">Impossible de contacter l'API</div>
+        ) : (
+          <Skeleton className="h-20 w-full" />
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+

--- a/frontend/src/components/cards/index.ts
+++ b/frontend/src/components/cards/index.ts
@@ -1,3 +1,4 @@
 export * from './FunFactCard';
 export * from './WeatherClockCard';
 export * from './InvoicePieChart';
+export * from './ApiInfoCard';

--- a/frontend/src/pages/Accueil.tsx
+++ b/frontend/src/pages/Accueil.tsx
@@ -1,6 +1,11 @@
 import { Link } from 'react-router-dom';
 import { FileText, Plus, BarChart3, Users } from 'lucide-react';
-import { FunFactCard, WeatherClockCard, InvoicePieChart } from '@/components/cards';
+import {
+  FunFactCard,
+  WeatherClockCard,
+  InvoicePieChart,
+  ApiInfoCard,
+} from '@/components/cards';
 
 export default function Accueil() {
   return (
@@ -42,6 +47,7 @@ export default function Accueil() {
         <FunFactCard />
         <WeatherClockCard />
         <InvoicePieChart />
+        <ApiInfoCard />
       </div>
 
         {/* Action Cards */}


### PR DESCRIPTION
## Summary
- add card to show API endpoints and health
- fetch and cache API health status
- update home page to display the new card
- export new card in cards index
- add .gitignore for node modules

## Testing
- `pnpm test` in `frontend`
- `pnpm test` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_6856fec17444832f94ca8c39854beb26