### PR TITLE
Remove body-parser usage

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -10,7 +10,6 @@
     "test": "jest"
   },
   "dependencies": {
-    "body-parser": "^1.20.2",
     "cors": "^2.8.5",
     "express": "^4.18.2",
     "pdfkit": "^0.13.0",

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,6 +1,5 @@
 const express = require('express');
 const cors = require('cors');
-const bodyParser = require('body-parser');
 const path = require('path');
 const buildFacturePDF = require('./services/pdfService');
 const tmp = require('tmp');
@@ -11,8 +10,8 @@ const PORT = process.env.PORT || 3001;
 
 // Middleware
 app.use(cors());
-app.use(bodyParser.json());
-app.use(bodyParser.urlencoded({ extended: true }));
+app.use(express.json());
+app.use(express.urlencoded({ extended: true }));
 
 // Base de données JSON
 const db = new JSONDatabase();


### PR DESCRIPTION
## Summary
- use `express.json()`/`express.urlencoded()` in server
- drop `body-parser` from backend dependencies

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685705fba750832f8d16a8e6e69c629f