### PR TITLE
Remove API card from home page

### DIFF
--- a/frontend/src/pages/Accueil.tsx
+++ b/frontend/src/pages/Accueil.tsx
@@ -4,7 +4,6 @@ import {
   FunFactCard,
   WeatherClockCard,
   InvoicePieChart,
-  ApiInfoCard,
 } from '@/components/cards';
 
 export default function Accueil() {
@@ -47,7 +46,6 @@ export default function Accueil() {
         <FunFactCard />
         <WeatherClockCard />
         <InvoicePieChart />
-        <ApiInfoCard />
       </div>
 
         {/* Action Cards */}


### PR DESCRIPTION
## Summary
- drop `ApiInfoCard` from Accueil page

## Testing
- `pnpm test --silent` in `frontend`
- `npx jest tests/health.test.js --runInBand` in `backend`
- `npx jest tests/validation.test.js --runInBand` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_685712d63c60832fac4eb53bd56e0628