### PR TITLE
Fix ts compilation for invoice totals

### DIFF
--- a/backend/invoiceGenerator.ts
+++ b/backend/invoiceGenerator.ts
@@ -86,7 +86,7 @@ export interface Totals {
  * Calculate totals for the provided invoice lines.
  */
 export function computeTotals(
-  lignes: InvoiceData['lignes'],
+  lignes: ReadonlyArray<{ description: string; quantite: number; prix_unitaire: number }>,
   tvaRate: number = 20
 ): Totals {
   const totalHT = lignes.reduce(
@@ -238,7 +238,7 @@ export async function generateInvoicePDF(
   });
 
   // Totals
-  const totals = computeTotals(parsed.lignes, parsed.tvaRate);
+  const totals = computeTotals(parsed.lignes as InvoiceData['lignes'], parsed.tvaRate);
   const boxWidth = 140;
   const boxX = layout.margin + pageWidth - boxWidth;
   doc.moveDown();


### PR DESCRIPTION
## Summary
- fix TypeScript compile error in invoice generator by updating `computeTotals`
- cast parsed lines when calculating totals

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`
- `npx tsc -p tsconfig.json`

------
https://chatgpt.com/codex/tasks/task_e_685714ed39c0832f8bb975a3f9f0c47b