### PR TITLE
Add Quote and sunset cards

### DIFF
--- a/frontend/src/components/cards/QuoteCard.test.tsx
+++ b/frontend/src/components/cards/QuoteCard.test.tsx
@@ -1,0 +1,15 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { QuoteCard } from './QuoteCard';
+
+global.fetch = jest
+  .fn()
+  .mockResolvedValueOnce({ json: () => Promise.resolve([{ q: 'hello', a: 'me' }]) })
+  .mockResolvedValueOnce({ json: () => Promise.resolve({ translatedText: 'bonjour' }) });
+
+test('affiche la citation traduite', async () => {
+  render(<QuoteCard />);
+  await waitFor(() => expect(screen.getByText(/bonjour/)).toBeInTheDocument());
+  expect(screen.getByText(/me/)).toBeInTheDocument();
+});
+

--- a/frontend/src/components/cards/QuoteCard.tsx
+++ b/frontend/src/components/cards/QuoteCard.tsx
@@ -1,0 +1,65 @@
+import { useEffect, useState } from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+
+interface QuoteState {
+  text: string;
+  author: string;
+}
+
+export function QuoteCard() {
+  const [quote, setQuote] = useState<QuoteState | null>(null);
+
+  useEffect(() => {
+    const key = 'quote-cache';
+    const cached = localStorage.getItem(key);
+    if (cached) {
+      try {
+        const parsed = JSON.parse(cached) as { data: QuoteState; ts: number };
+        if (Date.now() - parsed.ts < 24 * 60 * 60 * 1000) {
+          setQuote(parsed.data);
+          return;
+        }
+      } catch {
+        /* ignore */
+      }
+    }
+
+    async function load() {
+      try {
+        const [{ q, a }] = await fetch('https://zenquotes.io/api/random').then(r => r.json());
+        const body = { q, source: 'en', target: 'fr', format: 'text' };
+        const { translatedText } = await fetch('https://libretranslate.de/translate', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body)
+        }).then(r => r.json());
+        const data = { text: translatedText, author: a };
+        setQuote(data);
+        localStorage.setItem(key, JSON.stringify({ data, ts: Date.now() }));
+      } catch {
+        setQuote({ text: '', author: '' });
+      }
+    }
+    load();
+  }, []);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Citation du jour</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {quote ? (
+          <blockquote>
+            “{quote.text}”<br />
+            <span className="text-sm">— {quote.author}</span>
+          </blockquote>
+        ) : (
+          <Skeleton className="h-20 w-full" />
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+

--- a/frontend/src/components/cards/SunsetImageCard.test.tsx
+++ b/frontend/src/components/cards/SunsetImageCard.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { SunsetImageCard } from './SunsetImageCard';
+
+jest.mock('@/lib/api', () => ({ GEMINI_API_KEY: 'key' }));
+
+global.fetch = jest.fn(() =>
+  Promise.resolve({
+    json: () => Promise.resolve({
+      candidates: [{ content: { parts: [{ inlineData: { data: 'imgdata' } }] } }]
+    })
+  })
+) as jest.Mock;
+
+test('affiche une image', async () => {
+  render(<SunsetImageCard />);
+  const img = await screen.findByRole('img');
+  expect(img.src).toContain('data:image/png;base64,imgdata');
+});
+

--- a/frontend/src/components/cards/SunsetImageCard.tsx
+++ b/frontend/src/components/cards/SunsetImageCard.tsx
@@ -1,0 +1,46 @@
+import { useEffect, useState } from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+import { GEMINI_API_KEY } from '@/lib/api';
+
+export function SunsetImageCard() {
+  const [img, setImg] = useState('');
+
+  useEffect(() => {
+    async function load() {
+      if (!GEMINI_API_KEY) return;
+      try {
+        const prompt = 'Ultra-wide photograph of a breathtaking sunset over the ocean horizon, vivid orange and pink clouds, atmospheric, 4K';
+        const genBody = {
+          contents: [{ parts: [{ text: prompt }] }],
+          generationConfig: { responseModalities: ['IMAGE'] }
+        };
+        const res = await fetch(
+          `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash-preview-image-generation:generateContent?key=${GEMINI_API_KEY}`,
+          {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(genBody)
+          }
+        ).then(r => r.json());
+        const data = res.candidates?.[0]?.content?.parts?.[0]?.inlineData?.data;
+        if (data) setImg(`data:image/png;base64,${data}`);
+      } catch {
+        setImg('');
+      }
+    }
+    load();
+  }, []);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Coucher de soleil</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {img ? <img src={img} alt="Coucher de soleil" /> : <Skeleton className="h-40 w-full" />}
+      </CardContent>
+    </Card>
+  );
+}
+

--- a/frontend/src/components/cards/index.ts
+++ b/frontend/src/components/cards/index.ts
@@ -2,3 +2,5 @@ export * from './FunFactCard';
 export * from './WeatherClockCard';
 export * from './InvoicePieChart';
 export * from './ApiInfoCard';
+export * from './QuoteCard';
+export * from './SunsetImageCard';

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -2,3 +2,8 @@ export const API_URL =
   typeof import.meta !== 'undefined' && (import.meta as any).env?.VITE_API_URL
     ? (import.meta as any).env.VITE_API_URL
     : 'http://localhost:3001/api';
+
+export const GEMINI_API_KEY =
+  typeof import.meta !== 'undefined' && (import.meta as any).env?.VITE_GEMINI_API_KEY
+    ? (import.meta as any).env.VITE_GEMINI_API_KEY
+    : '';

--- a/frontend/src/pages/Accueil.tsx
+++ b/frontend/src/pages/Accueil.tsx
@@ -1,8 +1,8 @@
 import { Link } from 'react-router-dom';
 import { FileText, Plus, BarChart3, Users } from 'lucide-react';
 import {
-  FunFactCard,
-  WeatherClockCard,
+  QuoteCard,
+  SunsetImageCard,
   InvoicePieChart,
 } from '@/components/cards';
 
@@ -43,8 +43,8 @@ export default function Accueil() {
       </div>
 
       <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 mb-12">
-        <FunFactCard />
-        <WeatherClockCard />
+        <QuoteCard />
+        <SunsetImageCard />
         <InvoicePieChart />
       </div>
 


### PR DESCRIPTION
## Summary
- add quote and sunset cards with API integration
- expose GEMINI_API_KEY environment constant
- update homepage to show new cards
- test new cards

## Testing
- `pnpm test` in `frontend`
- `pnpm test` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_685715f2c240832f893a25cd40fcd4a7