### PR TITLE
Unify invoice total calculations

### DIFF
--- a/backend/services/pdfService.js
+++ b/backend/services/pdfService.js
@@ -6,15 +6,15 @@ function mapFactureToInvoiceData(facture) {
   return {
     nom_entreprise: facture.nom_entreprise || '',
     siren: facture.siren || '',
-    adresse: facture.adresse ? facture.adresse.split('\n') : undefined,
+    adresse: undefined,
     logo_path: facture.logo_path
       ? path.isAbsolute(facture.logo_path)
         ? facture.logo_path
         : path.join(__dirname, '..', facture.logo_path)
       : undefined,
     nom_client: facture.nom_client,
-    adresse_client: facture.adresse_client
-      ? facture.adresse_client.split('\n')
+    adresse_client: facture.adresse
+      ? facture.adresse.split('\n')
       : undefined,
     numero: facture.numero_facture || facture.numero,
     date: facture.date_facture,

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -4,3 +4,22 @@ import { twMerge } from 'tailwind-merge';
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
+
+export interface Totals {
+  totalHT: number;
+  totalTVA: number;
+  totalTTC: number;
+}
+
+export function computeTotals(
+  lignes: Array<{ quantite: number; prix_unitaire: number }>,
+  tvaRate = 20
+): Totals {
+  const totalHT = lignes.reduce(
+    (sum, l) => sum + l.quantite * l.prix_unitaire,
+    0
+  );
+  const totalTVA = (totalHT * tvaRate) / 100;
+  const totalTTC = totalHT + totalTVA;
+  return { totalHT, totalTVA, totalTTC };
+}

--- a/frontend/src/pages/CreerFacture.tsx
+++ b/frontend/src/pages/CreerFacture.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { ArrowLeft, Plus, Trash2, Save, Calculator } from 'lucide-react';
 import { API_URL } from '@/lib/api';
+import { computeTotals } from '@/lib/utils';
 
 interface LigneFacture {
   description: string;
@@ -67,13 +68,10 @@ export default function CreerFacture() {
     }
   }
 
-  // Calcul du montant total
-  const montantTotal = lignes.reduce((total, ligne) => {
-    return total + (ligne.quantite * ligne.prix_unitaire);
-  }, 0);
-
-  // Prix HT calculé à partir du montant TTC
-  const montantHT = montantTotal / 1.2;
+  const { totalHT: montantHT, totalTTC: montantTotal } = computeTotals(
+    lignes,
+    vatRate
+  );
 
   // Formatage des devises en français
   const formatEuro = (amount: number) => {

--- a/frontend/src/pages/ModifierFacture.tsx
+++ b/frontend/src/pages/ModifierFacture.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback } from 'react';
 import { Link, useParams, useNavigate } from 'react-router-dom';
 import { ArrowLeft, Plus, Trash2, Save, Calculator } from 'lucide-react';
 import { API_URL } from '@/lib/api';
+import { computeTotals } from '@/lib/utils';
 
 interface LigneFacture {
   description: string;
@@ -148,10 +149,10 @@ export default function ModifierFacture() {
     }
   }, [id, chargerFacture]);
 
-  // Calcul du montant total
-  const montantTotal = lignes.reduce((total, ligne) => {
-    return total + (ligne.quantite * ligne.prix_unitaire);
-  }, 0);
+  const { totalHT: montantHT, totalTTC: montantTotal } = computeTotals(
+    lignes,
+    vatRate
+  );
 
   // Formatage des devises en français
   const formatEuro = (amount: number) => {


### PR DESCRIPTION
## Summary
- expose computeTotals in frontend utils
- use computeTotals when creating or editing invoices
- map client address correctly when generating PDFs

## Testing
- `pnpm test` in `frontend`
- `pnpm test` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_685716a6f7f8832fa72a9305ec10b6c3