### PR TITLE
Fix TypeScript test build

### DIFF
--- a/frontend/src/components/cards/SunsetImageCard.test.tsx
+++ b/frontend/src/components/cards/SunsetImageCard.test.tsx
@@ -14,7 +14,7 @@ global.fetch = jest.fn(() =>
 
 test('affiche une image', async () => {
   render(<SunsetImageCard />);
-  const img = await screen.findByRole('img');
+  const img = (await screen.findByRole('img')) as HTMLImageElement;
   expect(img.src).toContain('data:image/png;base64,imgdata');
 });
 


### PR DESCRIPTION
## Summary
- fix SunsetImageCard test by casting returned element to HTMLImageElement

## Testing
- `pnpm test` in `frontend`
- `pnpm test` in `backend`
- `./install.sh`

------
https://chatgpt.com/codex/tasks/task_e_68571bb0072c832f868b9280c9633878