### PR TITLE
Improve clients page UI

### DIFF
--- a/frontend/src/pages/Clients.tsx
+++ b/frontend/src/pages/Clients.tsx
@@ -1,5 +1,15 @@
 import { useState, useEffect, FormEvent } from 'react'
+import { Plus, X } from 'lucide-react'
 import { API_URL } from '@/lib/api'
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardContent
+} from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Button } from '@/components/ui/button'
 
 interface Client {
   id: number
@@ -16,6 +26,7 @@ export default function Clients() {
   const [entreprise, setEntreprise] = useState('')
   const [telephone, setTelephone] = useState('')
   const [adresse, setAdresse] = useState('')
+  const [showForm, setShowForm] = useState(false)
 
   const chargerClients = async () => {
     const res = await fetch(`${API_URL}/clients`)
@@ -53,53 +64,79 @@ export default function Clients() {
 
   return (
     <div className="p-6 space-y-6">
-      <h2 className="text-2xl font-bold">Clients récurrents</h2>
-      <form onSubmit={creerClient} className="space-y-4 max-w-md">
-        <div>
-          <label className="block text-sm font-medium">Nom *</label>
-          <input
-            className="border rounded w-full px-2 py-1"
-            value={nom}
-            onChange={(e) => setNom(e.target.value)}
-          />
-        </div>
-        <div>
-          <label className="block text-sm font-medium">Entreprise</label>
-          <input
-            className="border rounded w-full px-2 py-1"
-            value={entreprise}
-            onChange={(e) => setEntreprise(e.target.value)}
-          />
-        </div>
-        <div>
-          <label className="block text-sm font-medium">Téléphone</label>
-          <input
-            className="border rounded w-full px-2 py-1"
-            value={telephone}
-            onChange={(e) => setTelephone(e.target.value)}
-          />
-        </div>
-        <div>
-          <label className="block text-sm font-medium">Adresse</label>
-          <input
-            className="border rounded w-full px-2 py-1"
-            value={adresse}
-            onChange={(e) => setAdresse(e.target.value)}
-          />
-        </div>
-        <button type="submit" className="px-4 py-2 bg-blue-500 text-white rounded">
-          Ajouter
-        </button>
-      </form>
-      <ul className="space-y-2">
+      <h2 className="text-2xl font-bold mb-4">Gestion des clients</h2>
+      <div className="grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
+        <Card className="flex flex-col justify-center items-center p-6">
+          {!showForm ? (
+            <button
+              className="flex flex-col items-center space-y-2"
+              onClick={() => setShowForm(true)}
+            >
+              <Plus className="h-8 w-8" />
+              <span className="font-semibold">Nouveau client</span>
+            </button>
+          ) : (
+            <form onSubmit={creerClient} className="w-full space-y-2">
+              <div>
+                <Label>Nom *</Label>
+                <Input value={nom} onChange={(e) => setNom(e.target.value)} />
+              </div>
+              <div>
+                <Label>Entreprise</Label>
+                <Input
+                  value={entreprise}
+                  onChange={(e) => setEntreprise(e.target.value)}
+                />
+              </div>
+              <div>
+                <Label>Téléphone</Label>
+                <Input
+                  value={telephone}
+                  onChange={(e) => setTelephone(e.target.value)}
+                />
+              </div>
+              <div>
+                <Label>Adresse</Label>
+                <Input
+                  value={adresse}
+                  onChange={(e) => setAdresse(e.target.value)}
+                />
+              </div>
+              <div className="flex gap-2">
+                <Button type="submit">Ajouter</Button>
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => {
+                    setNom('')
+                    setEntreprise('')
+                    setTelephone('')
+                    setAdresse('')
+                    setShowForm(false)
+                  }}
+                >
+                  <X className="h-4 w-4 mr-1" /> Annuler
+                </Button>
+              </div>
+            </form>
+          )}
+        </Card>
         {clients.map((c) => (
-          <li key={c.id} className="border p-2 rounded">
-            <div className="font-semibold">{c.nom_client}</div>
-            {c.nom_entreprise && <div>{c.nom_entreprise}</div>}
-            <div className="text-sm">{c.factures.length} facture(s)</div>
-          </li>
+          <Card key={c.id}>
+            <CardHeader>
+              <CardTitle>{c.nom_client}</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-1 text-sm">
+              {c.nom_entreprise && <div>{c.nom_entreprise}</div>}
+              {c.telephone && <div>{c.telephone}</div>}
+              {c.adresse && <div>{c.adresse}</div>}
+              <div className="text-xs text-zinc-500">
+                {c.factures.length} facture(s)
+              </div>
+            </CardContent>
+          </Card>
         ))}
-      </ul>
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- show clients in grid of cards
- add a card to create a new client directly from the list

## Testing
- `cd backend && pnpm test`
- `cd frontend && pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68571d560fd8832fa0ff99795da869f5