### PR TITLE
Add client update capability

### DIFF
--- a/backend/database/storage.js
+++ b/backend/database/storage.js
@@ -393,6 +393,19 @@ class JSONDatabase {
     return newId;
   }
 
+  updateClient(id, data) {
+    const index = this.clients.findIndex(c => c.id === parseInt(id));
+    if (index === -1) return false;
+    this.clients[index] = {
+      ...this.clients[index],
+      ...data,
+      id: parseInt(id),
+      updated_at: new Date().toISOString()
+    };
+    this.writeData(this.clientsFile, this.clients);
+    return true;
+  }
+
   addFactureToClient(clientId, factureId) {
     const client = this.clients.find(c => c.id === parseInt(clientId));
     if (!client) return false;

--- a/backend/server.js
+++ b/backend/server.js
@@ -97,6 +97,28 @@ app.get('/api/clients/:id', (req, res) => {
   }
 });
 
+app.put('/api/clients/:id', (req, res) => {
+  try {
+    const { nom_client, nom_entreprise = '', telephone = '', adresse = '' } = req.body;
+    if (!nom_client) {
+      return res.status(400).json({ error: 'Nom du client requis' });
+    }
+    const success = db.updateClient(req.params.id, {
+      nom_client: nom_client.trim(),
+      nom_entreprise: nom_entreprise.trim(),
+      telephone: telephone.trim(),
+      adresse: adresse.trim()
+    });
+    if (!success) return res.status(404).json({ error: 'Client non trouvé' });
+    res.json({ success: true });
+  } catch (err) {
+    res.status(500).json({
+      error: 'Erreur lors de la mise à jour du client',
+      details: err.message
+    });
+  }
+});
+
 // GET /api/factures - Liste toutes les factures avec pagination et recherche
 app.get('/api/factures', (req, res) => {
   try {

--- a/backend/tests/clients.test.js
+++ b/backend/tests/clients.test.js
@@ -1,0 +1,23 @@
+const request = require('supertest');
+const app = require('../server');
+
+describe('Client update', () => {
+  test('PUT /api/clients/:id updates existing client', async () => {
+    const createRes = await request(app)
+      .post('/api/clients')
+      .send({ nom_client: 'Client Test', telephone: '111' });
+    expect(createRes.status).toBe(201);
+    const id = createRes.body.id;
+
+    const updateRes = await request(app)
+      .put(`/api/clients/${id}`)
+      .send({ nom_client: 'Client Updated', telephone: '222' });
+    expect(updateRes.status).toBe(200);
+    expect(updateRes.body.success).toBe(true);
+
+    const getRes = await request(app).get(`/api/clients/${id}`);
+    expect(getRes.status).toBe(200);
+    expect(getRes.body.nom_client).toBe('Client Updated');
+    expect(getRes.body.telephone).toBe('222');
+  });
+});

--- a/frontend/src/pages/Clients.tsx
+++ b/frontend/src/pages/Clients.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, FormEvent } from 'react'
-import { Plus, X } from 'lucide-react'
+import { Plus, X, Edit, Save } from 'lucide-react'
 import { API_URL } from '@/lib/api'
 import {
   Card,
@@ -27,6 +27,11 @@ export default function Clients() {
   const [telephone, setTelephone] = useState('')
   const [adresse, setAdresse] = useState('')
   const [showForm, setShowForm] = useState(false)
+  const [editingId, setEditingId] = useState<number | null>(null)
+  const [editNom, setEditNom] = useState('')
+  const [editEntreprise, setEditEntreprise] = useState('')
+  const [editTelephone, setEditTelephone] = useState('')
+  const [editAdresse, setEditAdresse] = useState('')
 
   const chargerClients = async () => {
     const res = await fetch(`${API_URL}/clients`)
@@ -58,6 +63,30 @@ export default function Clients() {
       setEntreprise('')
       setTelephone('')
       setAdresse('')
+      chargerClients()
+    }
+  }
+
+  const majClient = async (e: FormEvent) => {
+    e.preventDefault()
+    if (editingId === null) return
+    if (!editNom.trim()) return
+    const res = await fetch(`${API_URL}/clients/${editingId}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        nom_client: editNom,
+        nom_entreprise: editEntreprise,
+        telephone: editTelephone,
+        adresse: editAdresse
+      })
+    })
+    if (res.ok) {
+      setEditingId(null)
+      setEditNom('')
+      setEditEntreprise('')
+      setEditTelephone('')
+      setEditAdresse('')
       chargerClients()
     }
   }
@@ -122,19 +151,67 @@ export default function Clients() {
           )}
         </Card>
         {clients.map((c) => (
-          <Card key={c.id}>
-            <CardHeader>
-              <CardTitle>{c.nom_client}</CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-1 text-sm">
-              {c.nom_entreprise && <div>{c.nom_entreprise}</div>}
-              {c.telephone && <div>{c.telephone}</div>}
-              {c.adresse && <div>{c.adresse}</div>}
-              <div className="text-xs text-zinc-500">
-                {c.factures.length} facture(s)
-              </div>
-            </CardContent>
-          </Card>
+          editingId === c.id ? (
+            <Card key={c.id}>
+              <CardHeader>
+                <CardTitle>Modifier {c.nom_client}</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <form onSubmit={majClient} className="space-y-2">
+                  <div>
+                    <Label>Nom *</Label>
+                    <Input value={editNom} onChange={(e) => setEditNom(e.target.value)} />
+                  </div>
+                  <div>
+                    <Label>Entreprise</Label>
+                    <Input value={editEntreprise} onChange={(e) => setEditEntreprise(e.target.value)} />
+                  </div>
+                  <div>
+                    <Label>Téléphone</Label>
+                    <Input value={editTelephone} onChange={(e) => setEditTelephone(e.target.value)} />
+                  </div>
+                  <div>
+                    <Label>Adresse</Label>
+                    <Input value={editAdresse} onChange={(e) => setEditAdresse(e.target.value)} />
+                  </div>
+                  <div className="flex gap-2">
+                    <Button type="submit"><Save className="h-4 w-4 mr-1" /> Sauvegarder</Button>
+                    <Button type="button" variant="outline" onClick={() => setEditingId(null)}>
+                      <X className="h-4 w-4 mr-1" /> Annuler
+                    </Button>
+                  </div>
+                </form>
+              </CardContent>
+            </Card>
+          ) : (
+            <Card key={c.id}>
+              <CardHeader>
+                <div className="flex justify-between items-start">
+                  <CardTitle>{c.nom_client}</CardTitle>
+                  <button
+                    onClick={() => {
+                      setEditingId(c.id)
+                      setEditNom(c.nom_client)
+                      setEditEntreprise(c.nom_entreprise || '')
+                      setEditTelephone(c.telephone || '')
+                      setEditAdresse(c.adresse || '')
+                    }}
+                    className="p-1 text-gray-600 hover:text-blue-600"
+                  >
+                    <Edit className="h-4 w-4" />
+                  </button>
+                </div>
+              </CardHeader>
+              <CardContent className="space-y-1 text-sm">
+                {c.nom_entreprise && <div>{c.nom_entreprise}</div>}
+                {c.telephone && <div>{c.telephone}</div>}
+                {c.adresse && <div>{c.adresse}</div>}
+                <div className="text-xs text-zinc-500">
+                  {c.factures.length} facture(s)
+                </div>
+              </CardContent>
+            </Card>
+          )
         ))}
       </div>
     </div>


### PR DESCRIPTION
## Summary
- allow updating client info in JSON storage
- expose `PUT /api/clients/:id` API
- support editing clients from the UI
- test client update route

## Testing
- `npx jest --runInBand` in `backend`
- `npx jest --runInBand` in `frontend`

------
https://chatgpt.com/codex/tasks/task_e_6857216803d0832fbed88037da2e0c37