### PR TITLE
Fix server startup for client creation

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -22,6 +22,7 @@
   },
   "devDependencies": {
     "nodemon": "^3.0.1",
+    "@types/numeral": "^2.0.5",
     "jest": "^29.6.1",
     "supertest": "^6.3.3",
     "ts-jest": "^29.4.0"

--- a/backend/pnpm-lock.yaml
+++ b/backend/pnpm-lock.yaml
@@ -36,6 +36,9 @@ importers:
         specifier: ^3.24.1
         version: 3.25.67
     devDependencies:
+      '@types/numeral':
+        specifier: ^2.0.5
+        version: 2.0.5
       jest:
         specifier: ^29.6.1
         version: 29.7.0(@types/node@24.0.3)(ts-node@10.9.2(@types/node@24.0.3)(typescript@5.8.3))
@@ -369,6 +372,9 @@ packages:
 
   '@types/node@24.0.3':
     resolution: {integrity: sha512-R4I/kzCYAdRLzfiCabn9hxWfbuHS573x+r0dJMkkzThEa7pbrcDWK+9zu3e7aBOouf+rQAciqPFMnxwr0aWgKg==}
+
+  '@types/numeral@2.0.5':
+    resolution: {integrity: sha512-kH8I7OSSwQu9DS9JYdFWbuvhVzvFRoCPCkGxNwoGgaPeDfEPJlcxNvEOypZhQ3XXHsGbfIuYcxcJxKUfJHnRfw==}
 
   '@types/stack-utils@2.0.3':
     resolution: {integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==}
@@ -2109,6 +2115,8 @@ snapshots:
   '@types/node@24.0.3':
     dependencies:
       undici-types: 7.8.0
+
+  '@types/numeral@2.0.5': {}
 
   '@types/stack-utils@2.0.3': {}
 

--- a/backend/services/htmlService.js
+++ b/backend/services/htmlService.js
@@ -1,4 +1,4 @@
-require('ts-node/register');
+require('ts-node/register/transpile-only');
 const path = require('path');
 const { generateInvoiceHTML } = require('../invoiceHTML.ts');
 


### PR DESCRIPTION
## Summary
- install `@types/numeral` dev dependency for backend
- use ts-node transpile-only mode to compile `invoiceHTML.ts`

## Testing
- `pnpm test` in `backend`
- `pnpm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_68572c073160832f87e68d88cd35a14e