### PR TITLE
Make HT/TTC calculations consistent

### DIFF
--- a/backend/invoiceHTML.ts
+++ b/backend/invoiceHTML.ts
@@ -1,5 +1,7 @@
 import { z } from 'zod';
 import Decimal from 'decimal.js';
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { computeTotals } = require('./utils/computeTotals.ts');
 import { format } from 'date-fns';
 import { fr } from 'date-fns/locale';
 import numeral from 'numeral';
@@ -47,28 +49,6 @@ const invoiceSchema = z.object({
   penalites: z.string(),
 });
 
-export interface Totals {
-  totalHT: number;
-  totalTVA: number;
-  totalTTC: number;
-}
-
-export function computeTotals(
-  lignes: ReadonlyArray<{ description: string; quantite: number; prix_unitaire: number }>,
-  tvaRate: number = 20
-): Totals {
-  const totalHT = lignes.reduce(
-    (sum, l) => sum.plus(new Decimal(l.quantite).mul(l.prix_unitaire)),
-    new Decimal(0)
-  );
-  const totalTVA = totalHT.mul(tvaRate).div(100);
-  const totalTTC = totalHT.plus(totalTVA);
-  return {
-    totalHT: Number(totalHT.toFixed(2)),
-    totalTVA: Number(totalTVA.toFixed(2)),
-    totalTTC: Number(totalTTC.toFixed(2)),
-  };
-}
 
 export function generateInvoiceHTML(data: InvoiceData): string {
   const parsed = invoiceSchema.parse(data);

--- a/backend/utils/computeTotals.ts
+++ b/backend/utils/computeTotals.ts
@@ -1,0 +1,24 @@
+import Decimal from 'decimal.js';
+
+export interface Totals {
+  totalHT: number;
+  totalTVA: number;
+  totalTTC: number;
+}
+
+export function computeTotals(
+  lignes: ReadonlyArray<{ quantite: number; prix_unitaire: number }>,
+  tvaRate: number = 20
+): Totals {
+  const totalHT = lignes.reduce(
+    (sum, l) => sum.plus(new Decimal(l.quantite).mul(l.prix_unitaire)),
+    new Decimal(0)
+  );
+  const totalTVA = totalHT.mul(tvaRate).div(100);
+  const totalTTC = totalHT.plus(totalTVA);
+  return {
+    totalHT: Number(totalHT.toFixed(2)),
+    totalTVA: Number(totalTVA.toFixed(2)),
+    totalTTC: Number(totalTTC.toFixed(2)),
+  };
+}


### PR DESCRIPTION
## Summary
- centralize total calculations in `backend/utils/computeTotals.ts`
- reuse `computeTotals` in invoice HTML generator
- use same logic when creating or updating invoices

## Testing
- `npm test --prefix backend` *(fails: jest not found)*
- `npm test --prefix frontend` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68572e9a6cbc832fabea9d627126dba6