### PR TITLE
Add Mistral invoice HTML endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,8 @@ Mam-s-Facture/
 - `POST /api/factures` - Créer une nouvelle facture
 - `PUT /api/factures/:id` - Modifier une facture
 - `DELETE /api/factures/:id` - Supprimer une facture
- - `GET /api/factures/:id/html` - Exporter la facture en HTML
+- `GET /api/factures/:id/html` - Exporter la facture en HTML
+- `GET /api/factures/:id/mistral-html` - Exporter la facture en HTML généré par Mistral
 - `GET /api/clients` - Liste des clients
 - `POST /api/clients` - Créer un client
 - `GET /api/clients/:id` - Détails d'un client

--- a/backend/server.js
+++ b/backend/server.js
@@ -4,6 +4,7 @@ const cors = require('cors');
 const bodyParser = require('body-parser');
 const path = require('path');
 const buildFactureHTML = require('./services/htmlService');
+const { generateMistralHTML } = require('./services/mistralService.ts');
 const JSONDatabase = require('./database/storage');
 const { computeTotals } = require('./utils/computeTotals.ts');
 
@@ -441,6 +442,24 @@ app.get('/api/factures/:id/html', (req, res) => {
     res.send(html);
   } catch (err) {
     res.status(500).json({ error: 'Erreur lors de la génération du HTML' });
+  }
+});
+
+// GET /api/factures/:id/mistral-html - Génère le HTML via Mistral
+app.get('/api/factures/:id/mistral-html', async (req, res) => {
+  const facture = db.getFactureById(req.params.id);
+  if (!facture) {
+    return res.status(404).json({ error: 'Facture non trouvée' });
+  }
+  try {
+    const html = await generateMistralHTML(facture);
+    res.setHeader('Content-Type', 'text/html; charset=utf-8');
+    res.send(html);
+  } catch (err) {
+    res.status(500).json({
+      error: 'Erreur lors de la génération du HTML via Mistral',
+      details: err.message
+    });
   }
 });
 

--- a/backend/services/htmlService.js
+++ b/backend/services/htmlService.js
@@ -34,3 +34,4 @@ function buildFactureHTML(facture) {
 }
 
 module.exports = buildFactureHTML;
+module.exports.mapFactureToInvoiceData = mapFactureToInvoiceData;

--- a/backend/services/mistralService.ts
+++ b/backend/services/mistralService.ts
@@ -1,0 +1,43 @@
+import { InvoiceData } from '../invoiceHTML';
+import { mapFactureToInvoiceData } from './htmlService';
+
+/**
+ * Generate professional invoice HTML using the Mistral model via OpenRouter.
+ * The environment variable OPENROUTER_API_KEY must be set.
+ */
+export async function generateMistralHTML(facture: any): Promise<string> {
+  const invoiceData: InvoiceData = mapFactureToInvoiceData(facture);
+  const apiKey = process.env.OPENROUTER_API_KEY;
+  if (!apiKey) {
+    throw new Error('OPENROUTER_API_KEY env var missing');
+  }
+
+  const response = await fetch('https://openrouter.ai/api/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      'Authorization': `Bearer ${apiKey}`,
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({
+      model: 'mistralai/mistral-small-3.2-24b-instruct:free',
+      messages: [
+        {
+          role: 'system',
+          content: 'Generate a professional French invoice in HTML using the provided JSON data.'
+        },
+        {
+          role: 'user',
+          content: JSON.stringify(invoiceData)
+        }
+      ]
+    })
+  });
+
+  if (!response.ok) {
+    const msg = await response.text();
+    throw new Error(`OpenRouter request failed: ${response.status} ${msg}`);
+  }
+
+  const data = await response.json();
+  return data?.choices?.[0]?.message?.content?.trim() || '';
+}


### PR DESCRIPTION
## Summary
- export `mapFactureToInvoiceData`
- add `mistralService.ts` using OpenRouter API
- expose `/api/factures/:id/mistral-html`
- document the new endpoint

## Testing
- `pnpm test` in backend
- `pnpm test` in frontend

------
https://chatgpt.com/codex/tasks/task_e_6857380944e0832fb287c18a9e2b46c2