### PR TITLE
Fix client creation

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -77,7 +77,8 @@ app.post('/api/clients', (req, res) => {
       telephone: telephone.trim(),
       adresse: adresse.trim()
     });
-    res.status(201).json({ id });
+    const client = db.getClientById(id);
+    res.status(201).json(client);
   } catch (err) {
     res.status(500).json({
       error: 'Erreur lors de la création du client',

--- a/backend/tests/clients.test.js
+++ b/backend/tests/clients.test.js
@@ -1,7 +1,20 @@
 const request = require('supertest');
 const app = require('../server');
 
-describe('Client update', () => {
+describe('Client endpoints', () => {
+  test('POST /api/clients creates a client', async () => {
+    const res = await request(app)
+      .post('/api/clients')
+      .send({ nom_client: 'Client Test', telephone: '111' });
+    expect(res.status).toBe(201);
+    expect(res.body.nom_client).toBe('Client Test');
+    const id = res.body.id;
+
+    const getRes = await request(app).get(`/api/clients/${id}`);
+    expect(getRes.status).toBe(200);
+    expect(getRes.body.id).toBe(id);
+  });
+
   test('PUT /api/clients/:id updates existing client', async () => {
     const createRes = await request(app)
       .post('/api/clients')

--- a/frontend/src/pages/Clients.tsx
+++ b/frontend/src/pages/Clients.tsx
@@ -63,7 +63,11 @@ export default function Clients() {
       setEntreprise('')
       setTelephone('')
       setAdresse('')
+      setShowForm(false)
       chargerClients()
+    } else {
+      const data = await res.json().catch(() => null)
+      alert(data?.error || 'Erreur lors de la création du client')
     }
   }
 


### PR DESCRIPTION
## Summary
- return created client when calling POST /api/clients
- hide form and show error on failure when adding a client
- add tests covering client creation

## Testing
- `cd backend && pnpm test`
- `cd frontend && pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68573adfe03c832fbec0701416c6203e