### PR TITLE
Add client profile directory

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,6 +6,7 @@ import CreerFacture from './pages/CreerFacture'
 import ModifierFacture from './pages/ModifierFacture'
 import DetailFacture from './pages/DetailFacture'
 import Clients from './pages/Clients'
+import ClientProfile from './pages/profiles/ClientProfile'
 import { ErrorBoundary } from './components/ErrorBoundary'
 import Sidebar from './components/Sidebar'
 import { ThemeProvider } from './context/ThemeContext'
@@ -25,6 +26,7 @@ function App() {
                 <Route path="/factures/:id" element={<DetailFacture />} />
                 <Route path="/factures/:id/modifier" element={<ModifierFacture />} />
                 <Route path="/clients" element={<Clients />} />
+                <Route path="/clients/:id" element={<ClientProfile />} />
               </Routes>
             </main>
           </div>

--- a/frontend/src/pages/Clients.tsx
+++ b/frontend/src/pages/Clients.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, FormEvent } from 'react'
 import { Plus, X, Edit, Save } from 'lucide-react'
+import { Link } from 'react-router-dom'
 import { API_URL } from '@/lib/api'
 import {
   Card,
@@ -208,6 +209,14 @@ export default function Clients() {
                 {c.adresse && <div>{c.adresse}</div>}
                 <div className="text-xs text-zinc-500">
                   {c.factures.length} facture(s)
+                </div>
+                <div>
+                  <Link
+                    to={`/clients/${c.id}`}
+                    className="text-blue-600 hover:underline text-sm"
+                  >
+                    Voir profil
+                  </Link>
                 </div>
               </CardContent>
             </Card>

--- a/frontend/src/pages/profiles/ClientProfile.tsx
+++ b/frontend/src/pages/profiles/ClientProfile.tsx
@@ -1,0 +1,60 @@
+import { useState, useEffect } from 'react'
+import { useParams, Link } from 'react-router-dom'
+import { API_URL } from '@/lib/api'
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card'
+import { ArrowLeft } from 'lucide-react'
+
+interface Client {
+  id: number
+  nom_client: string
+  nom_entreprise?: string
+  telephone?: string
+  adresse?: string
+  factures: number[]
+}
+
+export default function ClientProfile() {
+  const { id } = useParams<{ id: string }>()
+  const [client, setClient] = useState<Client | null>(null)
+
+  useEffect(() => {
+    const fetchClient = async () => {
+      const res = await fetch(`${API_URL}/clients/${id}`)
+      if (res.ok) {
+        const data = await res.json()
+        setClient(data)
+      }
+    }
+    if (id) fetchClient()
+  }, [id])
+
+  if (!client) {
+    return (
+      <div className="p-6">
+        <Link to="/clients" className="text-blue-600 hover:underline flex items-center mb-4">
+          <ArrowLeft className="h-4 w-4 mr-1" /> Retour
+        </Link>
+        <p>Client introuvable.</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="p-6 space-y-6">
+      <Link to="/clients" className="text-blue-600 hover:underline flex items-center">
+        <ArrowLeft className="h-4 w-4 mr-1" /> Retour
+      </Link>
+      <Card>
+        <CardHeader>
+          <CardTitle>{client.nom_client}</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-2 text-sm">
+          {client.nom_entreprise && <div>Entreprise : {client.nom_entreprise}</div>}
+          {client.telephone && <div>Téléphone : {client.telephone}</div>}
+          {client.adresse && <div>Adresse : {client.adresse}</div>}
+          <div>{client.factures.length} facture(s)</div>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add a page to display an individual client profile
- link from the client list to the profile page
- register the new profile route in the application router

## Testing
- `pnpm -C frontend test`
- `pnpm -C backend test`


------
https://chatgpt.com/codex/tasks/task_e_68574b4ea1b8832f8da3ed7b460fdb18