### PR TITLE
Replace VAT rate input with HT amount

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -239,10 +239,11 @@ app.post('/api/factures', (req, res) => {
       legal_form = '',
       vat_number = '',
       vat_rate = 0,
+      montant_total: montant_total_input = undefined,
       rcs_number = ''
     } = req.body;
     const parsedVatRate =
-      vat_rate !== undefined && vat_rate !== '' ? parseFloat(vat_rate) : 0;
+      vat_rate !== undefined && vat_rate !== '' ? parseFloat(vat_rate) : 20;
 
 
     // Validation
@@ -271,9 +272,13 @@ app.post('/api/factures', (req, res) => {
     }
 
 
-    // Calculer les montants HT/TTC
-    const { totalHT } = computeTotals(lignes, parsedVatRate);
-    const montant_total = totalHT;
+    let montant_total;
+    if (montant_total_input !== undefined && montant_total_input !== '') {
+      montant_total = parseFloat(montant_total_input);
+    } else {
+      const { totalHT } = computeTotals(lignes, parsedVatRate);
+      montant_total = totalHT;
+    }
 
     const numero_facture = numero_facture_input.trim() || generateInvoiceNumber();
 
@@ -337,10 +342,11 @@ app.put('/api/factures/:id', (req, res) => {
       legal_form = '',
       vat_number = '',
       vat_rate = 0,
+      montant_total: montant_total_input = undefined,
       rcs_number = ''
     } = req.body;
     const parsedVatRate =
-      vat_rate !== undefined && vat_rate !== '' ? parseFloat(vat_rate) : 0;
+      vat_rate !== undefined && vat_rate !== '' ? parseFloat(vat_rate) : 20;
 
 
     // Validation
@@ -367,9 +373,13 @@ app.put('/api/factures/:id', (req, res) => {
       }
     }
 
-    // Calculer les montants HT/TTC
-    const { totalHT } = computeTotals(lignes, parsedVatRate);
-    const montant_total = totalHT;
+    let montant_total;
+    if (montant_total_input !== undefined && montant_total_input !== '') {
+      montant_total = parseFloat(montant_total_input);
+    } else {
+      const { totalHT } = computeTotals(lignes, parsedVatRate);
+      montant_total = totalHT;
+    }
 
     const factureData = {
       ...(numero_facture_input ? { numero_facture: numero_facture_input.trim() } : {}),

--- a/backend/tests/clients.test.js
+++ b/backend/tests/clients.test.js
@@ -21,3 +21,19 @@ describe('Client update', () => {
     expect(getRes.body.telephone).toBe('222');
   });
 });
+
+describe('Client creation and listing', () => {
+  test('POST /api/clients adds client that appears in GET /api/clients', async () => {
+    const createRes = await request(app)
+      .post('/api/clients')
+      .send({ nom_client: 'Nouveau Client', telephone: '123' });
+    expect(createRes.status).toBe(201);
+    const id = createRes.body.id;
+
+    const listRes = await request(app).get('/api/clients');
+    expect(listRes.status).toBe(200);
+    const created = listRes.body.find(c => c.id === id);
+    expect(created).toBeTruthy();
+    expect(created.nom_client).toBe('Nouveau Client');
+  });
+});

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,6 +6,7 @@ import CreerFacture from './pages/CreerFacture'
 import ModifierFacture from './pages/ModifierFacture'
 import DetailFacture from './pages/DetailFacture'
 import Clients from './pages/Clients'
+import ClientProfile from './pages/profiles/ClientProfile'
 import { ErrorBoundary } from './components/ErrorBoundary'
 import Sidebar from './components/Sidebar'
 import { ThemeProvider } from './context/ThemeContext'
@@ -25,6 +26,7 @@ function App() {
                 <Route path="/factures/:id" element={<DetailFacture />} />
                 <Route path="/factures/:id/modifier" element={<ModifierFacture />} />
                 <Route path="/clients" element={<Clients />} />
+                <Route path="/clients/:id" element={<ClientProfile />} />
               </Routes>
             </main>
           </div>

--- a/frontend/src/pages/Clients.tsx
+++ b/frontend/src/pages/Clients.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, FormEvent } from 'react'
 import { Plus, X, Edit, Save } from 'lucide-react'
+import { Link } from 'react-router-dom'
 import { API_URL } from '@/lib/api'
 import {
   Card,
@@ -208,6 +209,14 @@ export default function Clients() {
                 {c.adresse && <div>{c.adresse}</div>}
                 <div className="text-xs text-zinc-500">
                   {c.factures.length} facture(s)
+                </div>
+                <div>
+                  <Link
+                    to={`/clients/${c.id}`}
+                    className="text-blue-600 hover:underline text-sm"
+                  >
+                    Voir profil
+                  </Link>
                 </div>
               </CardContent>
             </Card>

--- a/frontend/src/pages/CreerFacture.tsx
+++ b/frontend/src/pages/CreerFacture.tsx
@@ -2,7 +2,6 @@ import { useState, useEffect } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { ArrowLeft, Plus, Trash2, Save, Calculator } from 'lucide-react';
 import { API_URL } from '@/lib/api';
-import { computeTotals } from '@/lib/utils';
 import numeral from 'numeral';
 
 interface LigneFacture {
@@ -31,7 +30,7 @@ export default function CreerFacture() {
   const [siret, setSiret] = useState('');
   const [legalForm, setLegalForm] = useState('');
   const [vatNumber, setVatNumber] = useState('');
-  const [vatRate, setVatRate] = useState(20);
+  const [montantHTSaisi, setMontantHTSaisi] = useState(0);
   const [rcsNumber, setRcsNumber] = useState('');
   const [clients, setClients] = useState<Array<{id:number; nom_client:string; nom_entreprise?:string; telephone?:string; adresse?:string}>>([])
   const [clientId, setClientId] = useState<number | ''>('')
@@ -69,10 +68,9 @@ export default function CreerFacture() {
     }
   }
 
-  const { totalHT: montantHT, totalTTC: montantTotal } = computeTotals(
-    lignes,
-    vatRate
-  );
+  const TVA_RATE = 20;
+  const montantHT = montantHTSaisi;
+  const montantTotal = montantHTSaisi * (1 + TVA_RATE / 100);
 
   // Formatage des devises en français
   const formatEuro = (amount: number) => {
@@ -171,7 +169,7 @@ export default function CreerFacture() {
           siret: siret.trim(),
           legal_form: legalForm.trim(),
           vat_number: vatNumber.trim(),
-          vat_rate: vatRate,
+          montant_total: montantHTSaisi,
           rcs_number: rcsNumber.trim(),
           lignes: lignesValides
         }),
@@ -510,14 +508,14 @@ export default function CreerFacture() {
 
           <div className="mt-4">
             <label className="block text-sm font-medium text-gray-700 mb-1">
-              Taux de TVA (%)
+              Montant HT
             </label>
             <input
               type="number"
               min="0"
               step="0.01"
-              value={vatRate}
-              onChange={(e) => setVatRate(parseFloat(e.target.value) || 0)}
+              value={montantHTSaisi}
+              onChange={(e) => setMontantHTSaisi(parseFloat(e.target.value) || 0)}
               className="w-32 px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
             />
           </div>

--- a/frontend/src/pages/ModifierFacture.tsx
+++ b/frontend/src/pages/ModifierFacture.tsx
@@ -2,7 +2,6 @@ import { useState, useEffect, useCallback } from 'react';
 import { Link, useParams, useNavigate } from 'react-router-dom';
 import { ArrowLeft, Plus, Trash2, Save, Calculator } from 'lucide-react';
 import { API_URL } from '@/lib/api';
-import { computeTotals } from '@/lib/utils';
 import numeral from 'numeral';
 
 interface LigneFacture {
@@ -57,7 +56,7 @@ export default function ModifierFacture() {
   const [siret, setSiret] = useState('');
   const [legalForm, setLegalForm] = useState('');
   const [vatNumber, setVatNumber] = useState('');
-  const [vatRate, setVatRate] = useState(20);
+  const [montantHTSaisi, setMontantHTSaisi] = useState(0);
   const [rcsNumber, setRcsNumber] = useState('');
   const [clients, setClients] = useState<Array<{id:number; nom_client:string; nom_entreprise?:string; telephone?:string; adresse?:string}>>([])
   const [clientId, setClientId] = useState<number | ''>('')
@@ -124,7 +123,7 @@ export default function ModifierFacture() {
       setSiret(facture.siret || '');
       setLegalForm(facture.legal_form || '');
       setVatNumber(facture.vat_number || '');
-      setVatRate(facture.vat_rate ?? 20);
+      setMontantHTSaisi(facture.montant_total);
       setRcsNumber(facture.rcs_number || '');
       setClientId(facture.client_id ?? '')
       
@@ -150,10 +149,9 @@ export default function ModifierFacture() {
     }
   }, [id, chargerFacture]);
 
-  const { totalHT: montantHT, totalTTC: montantTotal } = computeTotals(
-    lignes,
-    vatRate
-  );
+  const TVA_RATE = 20;
+  const montantHT = montantHTSaisi;
+  const montantTotal = montantHTSaisi * (1 + TVA_RATE / 100);
 
   // Formatage des devises en français
   const formatEuro = (amount: number) => {
@@ -247,7 +245,7 @@ export default function ModifierFacture() {
           siret: siret.trim(),
           legal_form: legalForm.trim(),
           vat_number: vatNumber.trim(),
-          vat_rate: vatRate,
+          montant_total: montantHTSaisi,
           rcs_number: rcsNumber.trim(),
           lignes: lignesValides
         }),
@@ -481,13 +479,15 @@ export default function ModifierFacture() {
               />
             </div>
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-2">Taux de TVA (%)</label>
+              <label className="block text-sm font-medium text-gray-700 mb-2">Montant HT</label>
               <input
                 type="number"
                 min="0"
                 step="0.01"
-                value={vatRate}
-                onChange={(e) => setVatRate(parseFloat(e.target.value) || 0)}
+                value={montantHTSaisi}
+                onChange={(e) =>
+                  setMontantHTSaisi(parseFloat(e.target.value) || 0)
+                }
                 className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
               />
             </div>

--- a/frontend/src/pages/profiles/ClientProfile.tsx
+++ b/frontend/src/pages/profiles/ClientProfile.tsx
@@ -1,0 +1,60 @@
+import { useState, useEffect } from 'react'
+import { useParams, Link } from 'react-router-dom'
+import { API_URL } from '@/lib/api'
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card'
+import { ArrowLeft } from 'lucide-react'
+
+interface Client {
+  id: number
+  nom_client: string
+  nom_entreprise?: string
+  telephone?: string
+  adresse?: string
+  factures: number[]
+}
+
+export default function ClientProfile() {
+  const { id } = useParams<{ id: string }>()
+  const [client, setClient] = useState<Client | null>(null)
+
+  useEffect(() => {
+    const fetchClient = async () => {
+      const res = await fetch(`${API_URL}/clients/${id}`)
+      if (res.ok) {
+        const data = await res.json()
+        setClient(data)
+      }
+    }
+    if (id) fetchClient()
+  }, [id])
+
+  if (!client) {
+    return (
+      <div className="p-6">
+        <Link to="/clients" className="text-blue-600 hover:underline flex items-center mb-4">
+          <ArrowLeft className="h-4 w-4 mr-1" /> Retour
+        </Link>
+        <p>Client introuvable.</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="p-6 space-y-6">
+      <Link to="/clients" className="text-blue-600 hover:underline flex items-center">
+        <ArrowLeft className="h-4 w-4 mr-1" /> Retour
+      </Link>
+      <Card>
+        <CardHeader>
+          <CardTitle>{client.nom_client}</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-2 text-sm">
+          {client.nom_entreprise && <div>Entreprise : {client.nom_entreprise}</div>}
+          {client.telephone && <div>Téléphone : {client.telephone}</div>}
+          {client.adresse && <div>Adresse : {client.adresse}</div>}
+          <div>{client.factures.length} facture(s)</div>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- accept `montant_total` instead of `vat_rate` in invoice routes
- default VAT rate to 20
- ask users for Montant HT on invoice forms

## Testing
- `pnpm -C backend test`
- `pnpm -C frontend test`


------
https://chatgpt.com/codex/tasks/task_e_68574b4ea1b8832f8da3ed7b460fdb18