### PR TITLE
Add local HTML export script and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,8 +124,30 @@ Exemples :
 
 - **Production** : définir la variable lors du build ou sur votre hébergeur
   ```bash
-  VITE_API_URL=https://mon-domaine.com/api pnpm run build
-  ```
+    VITE_API_URL=https://mon-domaine.com/api pnpm run build
+    ```
+
+### Génération Mistral (OPENROUTER_API_KEY)
+
+L'endpoint `/api/factures/:id/mistral-html` permet de générer une facture en HTML via le modèle **Mistral**. Pour utiliser cette fonctionnalité, définissez la variable d'environnement `OPENROUTER_API_KEY` côté backend :
+
+```bash
+export OPENROUTER_API_KEY=ma-cle-api
+pnpm start
+```
+
+Si la variable n'est pas présente, l'API renverra une erreur « OPENROUTER_API_KEY env var missing » lors de l'appel à cet endpoint.
+
+### Génération locale (sans Mistral)
+
+Un script en ligne de commande permet d'exporter le HTML à partir des données locales :
+
+```bash
+cd backend
+pnpm run export-html <id_facture> [chemin_sortie]
+```
+
+L'endpoint `/api/factures/:id/html` renvoie également ce même HTML sans dépendre d'un service tiers.
 
 #### Lancement rapide sur macOS
 

--- a/backend/package.json
+++ b/backend/package.json
@@ -7,7 +7,8 @@
     "start": "node server.js",
     "dev": "nodemon server.js",
     "init-db": "node database/init.js",
-    "test": "jest"
+    "test": "jest",
+    "export-html": "node scripts/export-html.js"
   },
   "dependencies": {
     "body-parser": "^1.20.2",

--- a/backend/scripts/export-html.js
+++ b/backend/scripts/export-html.js
@@ -1,0 +1,37 @@
+require('ts-node/register/transpile-only');
+const fs = require('fs');
+const path = require('path');
+const Database = require('../database/storage');
+const buildFactureHTML = require('../services/htmlService');
+
+function usage() {
+  console.log('Usage: node scripts/export-html.js <id> [output]');
+}
+
+async function main() {
+  const id = process.argv[2];
+  if (!id) {
+    usage();
+    process.exit(1);
+  }
+
+  const output = process.argv[3] || `facture-${id}.html`;
+
+  const db = new Database();
+  const facture = db.getFactureById(id);
+  if (!facture) {
+    console.error('Facture not found');
+    process.exit(1);
+  }
+
+  try {
+    const html = buildFactureHTML(facture);
+    fs.writeFileSync(output, html, 'utf8');
+    console.log(`Facture HTML écrite dans ${output}`);
+  } catch (err) {
+    console.error('Erreur lors de la génération du HTML:', err.message);
+    process.exit(1);
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary
- script to export invoice HTML without Mistral
- document `pnpm run export-html` as a local alternative

## Testing
- `pnpm test` in `backend`
- `pnpm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_68575a1ada20832fb514ec5f51f48868