### PR TITLE
Migrate backend to SQLite via sql.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ backend/node_modules/
 # build outputs
 frontend/dist/
 backend/dist/
+backend/database/*.sqlite

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Application de Facturation Complète
 
-Une application web moderne et complète pour la gestion de factures, développée avec React, Node.js, et stockage JSON. Interface entièrement en français avec export HTML imprimable.
+Une application web moderne et complète pour la gestion de factures, développée avec React, Node.js, et stockage SQLite (sql.js). Interface entièrement en français avec export HTML imprimable.
 
 Pour une installation simplifiée, lancez `./install.sh` à la racine du projet. Ce script installe toutes les dépendances et construit automatiquement le frontend.
 
@@ -23,7 +23,7 @@ Pour une installation simplifiée, lancez `./install.sh` à la racine du projet.
 ### ✅ Fonctionnalités avancées
 - **Export HTML** prêt pour impression
 - **Formatage français** des dates (DD/MM/YYYY) et devises (€)
-- **Stockage persistant** avec fichiers JSON
+- **Stockage persistant** via SQLite (sql.js)
 - **API RESTful** complète avec gestion d'erreurs
 - **Interface entièrement en français**
 
@@ -160,11 +160,9 @@ Ce script renseigne également le champ `vat_rate` (taux de TVA) à `0` pour les
 ```
 Mam-s-Facture/
 ├── backend/                    # API Node.js/Express
-│   ├── database/              # Système de stockage JSON
-│   │   ├── storage.js         # Gestionnaire de base de données JSON
-│   │   └── data/              # Fichiers de données (auto-créés)
-│   │       ├── factures.json  # Données des factures
-│   │       └── lignes.json    # Lignes de facturation
+│   ├── database/              # Stockage SQLite (sql.js)
+│   │   ├── sqlite.js          # Gestionnaire de base de données SQLite
+│   │   └── facturation.sqlite # Fichier de base de données
 │   ├── server.js              # Serveur Express principal
 │   └── package.json           # Dépendances backend
 ├── frontend/                   # Application React
@@ -274,16 +272,16 @@ L'application inclut des données d'exemple pour la démonstration :
 3. **Configuration** : Ajuster les URLs dans le frontend pour pointer vers votre API
 
 ### Sauvegardes
-- Les données sont stockées dans `backend/database/data/`
-- Sauvegarder ces fichiers JSON pour préserver les données
-- Simple restauration par copie des fichiers
+- Les données sont stockées dans `backend/database/facturation.sqlite`
+- Sauvegarder ce fichier pour préserver les données
+- Simple restauration par copie du fichier
 
 ## 🆘 Support
 
 ### Résolution de problèmes
 - **Port déjà utilisé** : Modifier le PORT dans server.js
 - **CORS errors** : Vérifier que le backend est démarré
-- **Données perdues** : Vérifier les fichiers JSON dans database/data/
+- **Données perdues** : Vérifier le fichier `facturation.sqlite` dans `backend/database`
 
 ### Logs et debugging
 - Logs serveur affichés dans la console backend

--- a/backend/database/sqlite.js
+++ b/backend/database/sqlite.js
@@ -3,8 +3,13 @@ const path = require('path');
 const initSqlJs = require('sql.js/dist/sql-asm.js');
 
 class SQLiteDatabase {
-  constructor() {
-    this.SQL = initSqlJs;
+  static async create() {
+    const SQL = await initSqlJs();
+    return new SQLiteDatabase(SQL);
+  }
+
+  constructor(SQL) {
+    this.SQL = SQL;
     this.dbPath = path.join(__dirname, 'facturation.sqlite');
     const fileExists = fs.existsSync(this.dbPath);
     this.db = new this.SQL.Database(fileExists ? fs.readFileSync(this.dbPath) : undefined);

--- a/backend/tests/clients.test.js
+++ b/backend/tests/clients.test.js
@@ -1,5 +1,8 @@
 const request = require('supertest');
-const app = require('../server');
+let app;
+beforeAll(async () => {
+  app = await require('../server');
+});
 
 describe('Client endpoints', () => {
   test('POST /api/clients creates a client', async () => {

--- a/backend/tests/exportHtml.test.js
+++ b/backend/tests/exportHtml.test.js
@@ -1,5 +1,8 @@
 const request = require('supertest');
-const app = require('../server');
+let app;
+beforeAll(async () => {
+  app = await require('../server');
+});
 
 describe('GET /api/factures/:id/html', () => {
   test('returns invoice HTML', async () => {

--- a/backend/tests/health.test.js
+++ b/backend/tests/health.test.js
@@ -1,5 +1,8 @@
 const request = require('supertest');
-const app = require('../server');
+let app;
+beforeAll(async () => {
+  app = await require('../server');
+});
 
 describe('GET /api/health', () => {
   it('returns API health status', async () => {
@@ -7,7 +10,7 @@ describe('GET /api/health', () => {
     expect(res.status).toBe(200);
 
     expect(res.body.status).toBe('OK');
-    expect(res.body.storage).toBe('JSON Files');
+    expect(res.body.storage).toBe('SQLite (sql.js)');
 
     // ensure timestamp is a valid ISO string
     const isoTimestamp = new Date(res.body.timestamp).toISOString();

--- a/backend/tests/validation.test.js
+++ b/backend/tests/validation.test.js
@@ -1,5 +1,8 @@
 const request = require('supertest');
-const app = require('../server');
+let app;
+beforeAll(async () => {
+  app = await require('../server');
+});
 
 describe('Validation of lignes', () => {
   test('POST rejects non positive quantity', async () => {


### PR DESCRIPTION
## Summary
- switch server to use SQLite database with sql.js
- adjust health route and startup logs for SQLite
- make database initialization async
- update tests to await server initialization
- document new SQLite storage in README
- ignore generated SQLite files

## Testing
- `cd backend && pnpm install && pnpm test`
- `cd frontend && pnpm install && pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68582e763434832fa39ca5b80ca1ee04