### PR TITLE
Update TVA calculations

### DIFF
--- a/backend/tests/computeTotals.test.js
+++ b/backend/tests/computeTotals.test.js
@@ -7,16 +7,16 @@ describe('computeTotals', () => {
       { quantite: 1, prix_unitaire: 20 }
     ];
     const { totalHT, totalTVA, totalTTC } = computeTotals(lignes);
-    expect(totalHT).toBe(40);
-    expect(totalTVA).toBe(8);
-    expect(totalTTC).toBe(48);
+    expect(totalHT).toBe(33.33);
+    expect(totalTVA).toBe(6.67);
+    expect(totalTTC).toBe(40);
   });
 
   test('calculates totals correctly with custom VAT', () => {
     const lignes = [{ quantite: 3, prix_unitaire: 15 }];
     const { totalHT, totalTVA, totalTTC } = computeTotals(lignes, 10);
-    expect(totalHT).toBe(45);
-    expect(totalTVA).toBe(4.5);
-    expect(totalTTC).toBe(49.5);
+    expect(totalHT).toBe(40.91);
+    expect(totalTVA).toBe(4.09);
+    expect(totalTTC).toBe(45);
   });
 });

--- a/backend/utils/computeTotals.ts
+++ b/backend/utils/computeTotals.ts
@@ -10,12 +10,13 @@ export function computeTotals(
   lignes: ReadonlyArray<{ quantite: number; prix_unitaire: number }>,
   tvaRate: number = 20
 ): Totals {
-  const totalHT = lignes.reduce(
+  const rate = new Decimal(tvaRate).div(100);
+  const totalTTC = lignes.reduce(
     (sum, l) => sum.plus(new Decimal(l.quantite).mul(l.prix_unitaire)),
     new Decimal(0)
   );
-  const totalTVA = totalHT.mul(tvaRate).div(100);
-  const totalTTC = totalHT.plus(totalTVA);
+  const totalHT = totalTTC.div(rate.plus(1));
+  const totalTVA = totalTTC.minus(totalHT);
   return {
     totalHT: Number(totalHT.toFixed(2)),
     totalTVA: Number(totalTVA.toFixed(2)),

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -16,12 +16,13 @@ export function computeTotals(
   lignes: Array<{ quantite: number; prix_unitaire: number }>,
   tvaRate = 20
 ): Totals {
-  const totalHT = lignes.reduce(
+  const rate = new Decimal(tvaRate).div(100);
+  const totalTTC = lignes.reduce(
     (sum, l) => sum.plus(new Decimal(l.quantite).mul(l.prix_unitaire)),
     new Decimal(0)
   );
-  const totalTVA = totalHT.mul(tvaRate).div(100);
-  const totalTTC = totalHT.plus(totalTVA);
+  const totalHT = totalTTC.div(rate.plus(1));
+  const totalTVA = totalTTC.minus(totalHT);
   return {
     totalHT: Number(totalHT.toFixed(2)),
     totalTVA: Number(totalTVA.toFixed(2)),

--- a/frontend/src/pages/DetailFacture.tsx
+++ b/frontend/src/pages/DetailFacture.tsx
@@ -3,6 +3,7 @@ import { Link, useParams, useNavigate } from 'react-router-dom';
 import { ArrowLeft, Edit, Download, Trash2, FileText, User, Calendar, Euro } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { API_URL } from '@/lib/api';
+import { computeTotals } from '@/lib/utils';
 import { saveAs } from 'file-saver';
 import numeral from 'numeral';
 import { format } from 'date-fns';
@@ -161,10 +162,11 @@ export default function DetailFacture() {
     );
   }
 
-  const totalHT = facture.montant_total;
-  const tauxTVA = facture.vat_rate ?? 0;
-  const montantTVA = totalHT * (tauxTVA / 100);
-  const totalTTC = totalHT + montantTVA;
+  const tauxTVA = facture.vat_rate ?? 20;
+  const { totalHT, totalTVA: montantTVA, totalTTC } = computeTotals(
+    facture.lignes.map(l => ({ quantite: l.quantite, prix_unitaire: l.prix_unitaire })),
+    tauxTVA
+  );
 
   return (
     <div className="min-h-screen">

--- a/frontend/src/pages/ModifierFacture.tsx
+++ b/frontend/src/pages/ModifierFacture.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback } from 'react';
 import { Link, useParams, useNavigate } from 'react-router-dom';
 import { ArrowLeft, Plus, Trash2, Save, Calculator } from 'lucide-react';
 import { API_URL } from '@/lib/api';
+import { computeTotals } from '@/lib/utils';
 import numeral from 'numeral';
 
 interface LigneFacture {
@@ -56,7 +57,6 @@ export default function ModifierFacture() {
   const [siret, setSiret] = useState('');
   const [legalForm, setLegalForm] = useState('');
   const [vatNumber, setVatNumber] = useState('');
-  const [montantHTSaisi, setMontantHTSaisi] = useState(0);
   const [rcsNumber, setRcsNumber] = useState('');
   const [clients, setClients] = useState<Array<{id:number; nom_client:string; nom_entreprise?:string; telephone?:string; adresse?:string}>>([])
   const [clientId, setClientId] = useState<number | ''>('')
@@ -123,7 +123,6 @@ export default function ModifierFacture() {
       setSiret(facture.siret || '');
       setLegalForm(facture.legal_form || '');
       setVatNumber(facture.vat_number || '');
-      setMontantHTSaisi(facture.montant_total);
       setRcsNumber(facture.rcs_number || '');
       setClientId(facture.client_id ?? '')
       
@@ -150,8 +149,10 @@ export default function ModifierFacture() {
   }, [id, chargerFacture]);
 
   const TVA_RATE = 20;
-  const montantHT = montantHTSaisi;
-  const montantTotal = montantHTSaisi * (1 + TVA_RATE / 100);
+  const { totalHT: montantHT, totalTTC: montantTotal } = computeTotals(
+    lignes,
+    TVA_RATE
+  );
 
   // Formatage des devises en français
   const formatEuro = (amount: number) => {
@@ -245,7 +246,6 @@ export default function ModifierFacture() {
           siret: siret.trim(),
           legal_form: legalForm.trim(),
           vat_number: vatNumber.trim(),
-          montant_total: montantHTSaisi,
           rcs_number: rcsNumber.trim(),
           lignes: lignesValides
         }),
@@ -479,19 +479,6 @@ export default function ModifierFacture() {
               />
             </div>
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-2">Montant HT</label>
-              <input
-                type="number"
-                min="0"
-                step="0.01"
-                value={montantHTSaisi}
-                onChange={(e) =>
-                  setMontantHTSaisi(parseFloat(e.target.value) || 0)
-                }
-                className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
-              />
-            </div>
-            <div>
               <label className="block text-sm font-medium text-gray-700 mb-2">N° RCS</label>
               <input
                 type="text"
@@ -559,8 +546,8 @@ export default function ModifierFacture() {
                     )}
                   </div>
                   <div className="md:col-span-2">
-                    <label className="block text-sm font-medium text-gray-700 mb-1">
-                      Prix unitaire (€)
+                  <label className="block text-sm font-medium text-gray-700 mb-1">
+                      Prix unitaire TTC (€)
                     </label>
                     <input
                       type="number"
@@ -572,6 +559,12 @@ export default function ModifierFacture() {
                         erreurs[`prix_${index}`] ? 'border-red-300' : 'border-gray-300'
                       }`}
                     />
+                    <p className="mt-1 text-xs text-gray-500">
+                      (TVA :{' '}
+                      {formatEuro(
+                        ligne.prix_unitaire - ligne.prix_unitaire / (1 + TVA_RATE / 100)
+                      )})
+                    </p>
                     {erreurs[`prix_${index}`] && (
                       <p className="mt-1 text-xs text-red-600">{erreurs[`prix_${index}`]}</p>
                     )}


### PR DESCRIPTION
## Summary
- compute totals from TTC values
- show VAT portion next to unit price on invoice forms
- calculate invoice totals from line items
- adjust invoice detail page to use new total calculation
- update unit tests

## Testing
- `cd backend && pnpm install && pnpm test`
- `cd frontend && pnpm install && pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_685839770ad4832f9612c65b178ad304