### PR TITLE
Add local quote API

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -6,6 +6,7 @@ const path = require('path');
 const buildFactureHTML = require('./services/htmlService');
 const SQLiteDatabase = require('./database/sqlite');
 const { computeTotals } = require('./utils/computeTotals.ts');
+const { getRandomQuote } = require('./services/quoteService');
 
 const app = express();
 const PORT = process.env.PORT || 3001;
@@ -487,6 +488,15 @@ app.get('/api/health', (req, res) => {
     timestamp: new Date().toISOString(),
     storage: 'SQLite (sql.js)'
   });
+});
+
+app.get('/api/quote', (req, res) => {
+  try {
+    const quote = getRandomQuote();
+    res.json(quote);
+  } catch {
+    res.status(500).json({ error: 'Erreur lors de la récupération de la citation' });
+  }
 });
 
 // Route pour le camembert factures payées vs impayées du mois courant

--- a/backend/services/quoteService.js
+++ b/backend/services/quoteService.js
@@ -1,0 +1,35 @@
+const fs = require('fs');
+const path = require('path');
+
+function getRandomQuote() {
+  const filePath = path.join(__dirname, '..', 'database', 'data', 'citations_bien_etre.json');
+  let content;
+  try {
+    content = fs.readFileSync(filePath, 'utf8');
+  } catch {
+    throw new Error('File not found');
+  }
+  let quotes;
+  try {
+    quotes = JSON.parse(content);
+  } catch {
+    throw new Error('Invalid JSON');
+  }
+  if (!Array.isArray(quotes) || quotes.length === 0) {
+    throw new Error('No quotes available');
+  }
+  const selected = quotes[Math.floor(Math.random() * quotes.length)];
+  let text = selected;
+  let author = '';
+  if (typeof selected === 'string') {
+    const separator = ' – ';
+    if (selected.includes(separator)) {
+      [text, author] = selected.split(separator).map(s => s.trim());
+    } else if (selected.includes(' - ')) {
+      [text, author] = selected.split(' - ').map(s => s.trim());
+    }
+  }
+  return { text, author };
+}
+
+module.exports = { getRandomQuote };

--- a/backend/tests/quote.test.js
+++ b/backend/tests/quote.test.js
@@ -1,0 +1,15 @@
+const request = require('supertest');
+let app;
+beforeAll(async () => {
+  app = await require('../server');
+});
+
+describe('GET /api/quote', () => {
+  test('returns a random quote', async () => {
+    const res = await request(app).get('/api/quote');
+    expect(res.status).toBe(200);
+    expect(typeof res.body.text).toBe('string');
+    expect(res.body.text.length).toBeGreaterThan(0);
+    expect(typeof res.body.author).toBe('string');
+  });
+});

--- a/frontend/src/components/cards/QuoteCard.test.tsx
+++ b/frontend/src/components/cards/QuoteCard.test.tsx
@@ -2,12 +2,11 @@ import { render, screen, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { QuoteCard } from './QuoteCard';
 
-global.fetch = jest
-  .fn()
-  .mockResolvedValueOnce({ json: () => Promise.resolve([{ q: 'hello', a: 'me' }]) })
-  .mockResolvedValueOnce({ json: () => Promise.resolve({ translatedText: 'bonjour' }) });
+global.fetch = jest.fn().mockResolvedValueOnce({
+  json: () => Promise.resolve({ text: 'bonjour', author: 'me' })
+});
 
-test('affiche la citation traduite', async () => {
+test('affiche la citation', async () => {
   render(<QuoteCard />);
   await waitFor(() => expect(screen.getByText(/bonjour/)).toBeInTheDocument());
   expect(screen.getByText(/me/)).toBeInTheDocument();

--- a/frontend/src/components/cards/QuoteCard.tsx
+++ b/frontend/src/components/cards/QuoteCard.tsx
@@ -27,14 +27,8 @@ export function QuoteCard() {
 
     async function load() {
       try {
-        const [{ q, a }] = await fetch('https://zenquotes.io/api/random').then(r => r.json());
-        const body = { q, source: 'en', target: 'fr', format: 'text' };
-        const { translatedText } = await fetch('https://libretranslate.de/translate', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(body)
-        }).then(r => r.json());
-        const data = { text: translatedText, author: a };
+        const { text, author } = await fetch('/api/quote').then(r => r.json());
+        const data = { text, author };
         setQuote(data);
         localStorage.setItem(key, JSON.stringify({ data, ts: Date.now() }));
       } catch {


### PR DESCRIPTION
## Summary
- implement `getRandomQuote` service using local JSON file
- expose new `/api/quote` endpoint in the backend
- update QuoteCard to fetch from backend
- adjust QuoteCard test for new data
- add backend test for quote route

## Testing
- `cd backend && pnpm install && pnpm test`
- `cd frontend && pnpm install && pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68583c26f7b4832fa084c288a91db6b4