### PR TITLE
Update macOS scripts

### DIFF
--- a/install_macos.sh
+++ b/install_macos.sh
@@ -24,8 +24,8 @@ if ! command -v node >/dev/null 2>&1; then
 fi
 
 if ! command -v pnpm >/dev/null 2>&1; then
-  echo "[installer] Installation de pnpm..."
-  npm install -g pnpm
+  echo "[installer] Installation de pnpm via Homebrew..."
+  brew install pnpm
 fi
 
 # Détermine si la version de Node est suffisante

--- a/launch_safari.sh
+++ b/launch_safari.sh
@@ -22,14 +22,17 @@ done
 
 cd "$(dirname "$0")"
 
+# Installe automatiquement les dépendances si nécessaire
+if ! command -v node >/dev/null 2>&1 \
+  || ! command -v pnpm >/dev/null 2>&1 \
+  || [ ! -d backend/node_modules ] || [ ! -d frontend/node_modules ]; then
+  echo "[launcher] Préparation de l'environnement (installation)..."
+  ./install_macos.sh --skip-build
+fi
+
 PM=pnpm
 if ! command -v pnpm >/dev/null 2>&1; then
   PM=npm
-fi
-
-if ! command -v node >/dev/null 2>&1; then
-  echo "[launcher] Node.js est requis. Installez-le avant de poursuivre." >&2
-  exit 1
 fi
 
 echo "[launcher] Démarrage du backend..."


### PR DESCRIPTION
## Summary
- install pnpm via Homebrew in `install_macos.sh`
- auto-run the installer from `launch_safari.sh` when dependencies are missing

## Testing
- `cd backend && pnpm install && pnpm test`
- `cd frontend && pnpm install && pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68583de494dc832fb3640e7b63f214cc