### PR TITLE
Improve navigation UX

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,6 +7,7 @@ import ModifierFacture from './pages/ModifierFacture'
 import DetailFacture from './pages/DetailFacture'
 import Clients from './pages/Clients'
 import ClientProfile from './pages/profiles/ClientProfile'
+import NotFound from './pages/Error/NotFound'
 import { ErrorBoundary } from './components/ErrorBoundary'
 import Sidebar from './components/Sidebar'
 import { ThemeProvider } from './context/ThemeContext'
@@ -27,6 +28,7 @@ function App() {
                 <Route path="/factures/:id/modifier" element={<ModifierFacture />} />
                 <Route path="/clients" element={<Clients />} />
                 <Route path="/clients/:id" element={<ClientProfile />} />
+                <Route path="*" element={<NotFound />} />
               </Routes>
             </main>
           </div>

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -1,13 +1,28 @@
 import { NavLink } from 'react-router-dom'
-import { Home, FileText, PlusCircle, CircleAlert, Sun, Users } from 'lucide-react'
+import { Home, FileText, PlusCircle, CircleAlert, Sun, Users, Menu, X } from 'lucide-react'
 import { useTheme } from '../context/ThemeContext'
+import { useIsMobile } from '../hooks/use-mobile'
+import { useState, useEffect } from 'react'
 
 export default function Sidebar() {
   const { theme, toggleTheme } = useTheme()
+  const isMobile = useIsMobile()
+  const [open, setOpen] = useState(!isMobile)
 
-  return (
-    <aside className="fixed left-0 top-0 h-full w-64 bg-sidebar p-6 text-sidebar-foreground shadow-lg">
-      <nav className="space-y-4">
+  useEffect(() => {
+    setOpen(!isMobile)
+  }, [isMobile])
+
+  const sidebar = (
+    <aside
+      className={`fixed left-0 top-0 z-50 h-full w-64 bg-sidebar p-6 text-sidebar-foreground shadow-lg transform transition-transform md:translate-x-0 ${open ? 'translate-x-0' : '-translate-x-full'}`}
+    >
+      {isMobile && (
+        <button onClick={() => setOpen(false)} className="absolute top-2 right-2 p-1">
+          <X className="h-5 w-5" />
+        </button>
+      )}
+      <nav className="space-y-4 mt-6">
         <NavLink to="/" className="flex items-center space-x-2 hover:text-primary">
           <Home className="h-5 w-5" />
           <span>Accueil</span>
@@ -34,5 +49,22 @@ export default function Sidebar() {
         </button>
       </nav>
     </aside>
+  )
+
+  return (
+    <>
+      {isMobile && !open && (
+        <button
+          onClick={() => setOpen(true)}
+          className="fixed top-2 left-2 z-40 p-2 bg-sidebar text-sidebar-foreground rounded-md shadow md:hidden"
+        >
+          <Menu className="h-5 w-5" />
+        </button>
+      )}
+      {isMobile && open && (
+        <div className="fixed inset-0 z-30 bg-black/50" onClick={() => setOpen(false)} />
+      )}
+      {sidebar}
+    </>
   )
 }

--- a/frontend/src/pages/Clients.tsx
+++ b/frontend/src/pages/Clients.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, FormEvent } from 'react'
-import { Plus, X, Edit, Save } from 'lucide-react'
-import { Link } from 'react-router-dom'
+import { Plus, X, Edit, Save, ArrowLeft } from 'lucide-react'
+import { Link, useNavigate } from 'react-router-dom'
 import { API_URL } from '@/lib/api'
 import {
   Card,
@@ -23,6 +23,7 @@ interface Client {
 
 export default function Clients() {
   const [clients, setClients] = useState<Client[]>([])
+  const navigate = useNavigate()
   const [nom, setNom] = useState('')
   const [entreprise, setEntreprise] = useState('')
   const [telephone, setTelephone] = useState('')
@@ -98,6 +99,13 @@ export default function Clients() {
 
   return (
     <div className="p-6 space-y-6">
+      <button
+        type="button"
+        onClick={() => (window.history.length > 1 ? navigate(-1) : navigate('/'))}
+        className="text-blue-600 hover:underline flex items-center"
+      >
+        <ArrowLeft className="h-4 w-4 mr-1" /> Retour
+      </button>
       <h2 className="text-2xl font-bold mb-4">Gestion des clients</h2>
       <div className="grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
         <Card className="flex flex-col justify-center items-center p-6">

--- a/frontend/src/pages/CreerFacture.tsx
+++ b/frontend/src/pages/CreerFacture.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { ArrowLeft, Plus, Trash2, Save, Calculator } from 'lucide-react';
 import LogoDropzone from '@/components/LogoDropzone';
 import { API_URL } from '@/lib/api';
@@ -14,6 +14,7 @@ interface LigneFacture {
 
 export default function CreerFacture() {
   const navigate = useNavigate();
+  const goBack = () => (window.history.length > 1 ? navigate(-1) : navigate('/'));
   
   // État du formulaire
   const [nomClient, setNomClient] = useState('');
@@ -201,10 +202,14 @@ export default function CreerFacture() {
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex justify-between items-center h-16">
             <div className="flex items-center">
-              <Link to="/factures" className="flex items-center text-gray-600 hover:text-gray-900 mr-4">
+              <button
+                type="button"
+                onClick={goBack}
+                className="flex items-center text-gray-600 hover:text-gray-900 mr-4"
+              >
                 <ArrowLeft className="h-5 w-5 mr-2" />
-                Retour à la liste
-              </Link>
+                Retour
+              </button>
               <h1 className="text-2xl font-bold text-gray-900">
                 Créer une nouvelle facture
               </h1>

--- a/frontend/src/pages/DetailFacture.tsx
+++ b/frontend/src/pages/DetailFacture.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
-import { Link, useParams, useNavigate } from 'react-router-dom';
+import { useParams, useNavigate } from 'react-router-dom';
 import { ArrowLeft, Edit, Download, Trash2, FileText, User, Calendar, Euro } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { API_URL } from '@/lib/api';
@@ -150,13 +150,14 @@ export default function DetailFacture() {
           <p className="text-gray-600 mb-6">
             La facture demandée n'existe pas ou a été supprimée.
           </p>
-          <Link
-            to="/factures"
+          <button
+            type="button"
+            onClick={() => (window.history.length > 1 ? navigate(-1) : navigate('/'))}
             className="inline-flex items-center px-4 py-2 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 transition-colors"
           >
             <ArrowLeft className="h-5 w-5 mr-2" />
-            Retour à la liste
-          </Link>
+            Retour
+          </button>
         </div>
       </div>
     );
@@ -177,10 +178,14 @@ export default function DetailFacture() {
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex justify-between items-center h-16">
             <div className="flex items-center">
-              <Link to="/factures" className="flex items-center text-gray-600 hover:text-gray-900 mr-4">
+              <button
+                type="button"
+                onClick={() => (window.history.length > 1 ? navigate(-1) : navigate('/'))}
+                className="flex items-center text-gray-600 hover:text-gray-900 mr-4"
+              >
                 <ArrowLeft className="h-5 w-5 mr-2" />
-                Retour à la liste
-              </Link>
+                Retour
+              </button>
               <FileText className="h-8 w-8 text-indigo-600 mr-3" />
               <div>
                 <h1 className="text-2xl font-bold text-gray-900">

--- a/frontend/src/pages/Error/NotFound.tsx
+++ b/frontend/src/pages/Error/NotFound.tsx
@@ -1,0 +1,18 @@
+import { useNavigate } from 'react-router-dom';
+
+export default function NotFound() {
+  const navigate = useNavigate();
+  const goHome = () => navigate('/');
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center space-y-4 p-4">
+      <h1 className="text-3xl font-bold">Page non trouvée</h1>
+      <p className="text-gray-600">La page demandée n'existe pas.</p>
+      <button
+        onClick={goHome}
+        className="px-4 py-2 bg-indigo-600 text-white rounded hover:bg-indigo-700"
+      >
+        Retour à l'accueil
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/pages/ModifierFacture.tsx
+++ b/frontend/src/pages/ModifierFacture.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
-import { Link, useParams, useNavigate } from 'react-router-dom';
+import { useParams, useNavigate } from 'react-router-dom';
 import { ArrowLeft, Plus, Trash2, Save, Calculator } from 'lucide-react';
 import LogoDropzone from '@/components/LogoDropzone';
 import { API_URL } from '@/lib/api';
@@ -43,6 +43,7 @@ interface Facture {
 export default function ModifierFacture() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
+  const goBack = () => (window.history.length > 1 ? navigate(-1) : navigate('/'));
   
   // État du formulaire
   const [nomClient, setNomClient] = useState('');
@@ -286,10 +287,14 @@ export default function ModifierFacture() {
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex justify-between items-center h-16">
             <div className="flex items-center">
-              <Link to={`/factures/${id}`} className="flex items-center text-gray-600 hover:text-gray-900 mr-4">
+              <button
+                type="button"
+                onClick={goBack}
+                className="flex items-center text-gray-600 hover:text-gray-900 mr-4"
+              >
                 <ArrowLeft className="h-5 w-5 mr-2" />
-                Retour aux détails
-              </Link>
+                Retour
+              </button>
               <h1 className="text-2xl font-bold text-gray-900">
                 Modifier la facture {factureOriginale?.numero_facture}
               </h1>

--- a/frontend/src/pages/profiles/ClientProfile.tsx
+++ b/frontend/src/pages/profiles/ClientProfile.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react'
-import { useParams, Link } from 'react-router-dom'
+import { useParams, useNavigate } from 'react-router-dom'
 import { API_URL } from '@/lib/api'
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card'
 import { ArrowLeft } from 'lucide-react'
@@ -15,6 +15,7 @@ interface Client {
 
 export default function ClientProfile() {
   const { id } = useParams<{ id: string }>()
+  const navigate = useNavigate()
   const [client, setClient] = useState<Client | null>(null)
 
   useEffect(() => {
@@ -31,9 +32,13 @@ export default function ClientProfile() {
   if (!client) {
     return (
       <div className="p-6">
-        <Link to="/clients" className="text-blue-600 hover:underline flex items-center mb-4">
+        <button
+          type="button"
+          onClick={() => (window.history.length > 1 ? navigate(-1) : navigate('/'))}
+          className="text-blue-600 hover:underline flex items-center mb-4"
+        >
           <ArrowLeft className="h-4 w-4 mr-1" /> Retour
-        </Link>
+        </button>
         <p>Client introuvable.</p>
       </div>
     )
@@ -41,9 +46,13 @@ export default function ClientProfile() {
 
   return (
     <div className="p-6 space-y-6">
-      <Link to="/clients" className="text-blue-600 hover:underline flex items-center">
+      <button
+        type="button"
+        onClick={() => (window.history.length > 1 ? navigate(-1) : navigate('/'))}
+        className="text-blue-600 hover:underline flex items-center"
+      >
         <ArrowLeft className="h-4 w-4 mr-1" /> Retour
-      </Link>
+      </button>
       <Card>
         <CardHeader>
           <CardTitle>{client.nom_client}</CardTitle>


### PR DESCRIPTION
## Summary
- add 404 `NotFound` page and route
- implement mobile-friendly sidebar with burger button
- add navigation back buttons using `useNavigate`
- expose go back option on clients, invoices and profiles pages

## Testing
- `cd backend && pnpm test`
- `cd frontend && pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6858459c0ccc832facb961fa440f9fbc