### PR TITLE
Fix dark theme input text visibility

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -93,3 +93,15 @@ body.app-fade {
     opacity: 1;
   }
 }
+
+@layer components {
+  /* Force black text for form fields on white background in dark theme */
+  .dark .bg-white input,
+  .dark .bg-white textarea,
+  .dark .bg-white select {
+    @apply text-black;
+  }
+  .input-theme-fix {
+    @apply text-black dark:text-black;
+  }
+}


### PR DESCRIPTION
## Summary
- ensure white-background form fields have readable text in dark mode
- add optional `input-theme-fix` utility class

## Testing
- `cd backend && pnpm install && pnpm test`
- `cd frontend && pnpm install && pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6858474ab1b8832f9eb06453087a01a6