### PR TITLE
Update invoice pdf template

### DIFF
--- a/backend/views/invoice.ejs
+++ b/backend/views/invoice.ejs
@@ -1,73 +1,146 @@
 <!DOCTYPE html>
 <html lang="fr">
 <head>
-  <meta charset="utf-8">
-  <title>Facture <%= numero %></title>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Facture</title>
   <style>
-    @page { size: A4; margin: 20mm 15mm; }
-    body.invoice { font: 14px/1.4 "Helvetica Neue", Arial, sans-serif; color:#333; }
-    header{ display:flex; justify-content:space-between; align-items:center; margin-bottom:32px; }
-    header img{ max-height:60px; }
-    .meta h1{ margin:0; font-size:28px; letter-spacing:2px; }
-    .addresses{ display:flex; justify-content:space-between; margin-bottom:24px; }
-    .addresses h2{ margin:0 0 8px; font-size:16px; }
-    table.lines{ width:100%; border-collapse:collapse; }
-    table.lines thead { background:#f2f6fa; }
-    table.lines th, table.lines td{ padding:8px; border:1px solid #ddd; text-align:left; }
-    table.lines td.price, .totals p{ text-align:right; }
-    .totals{ margin-top:16px; }
-    .totals .grand{ font-size:18px; font-weight:700; }
-    @media print{ table.lines tr{ break-inside:avoid; } }
+    body {
+      font-family: 'Helvetica Neue', sans-serif;
+      margin: 40px;
+      color: #000;
+    }
+    header, .info-client, .facture-titre, footer {
+      display: flex;
+      justify-content: space-between;
+    }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      margin-top: 20px;
+    }
+    th, td {
+      border: 1px solid #ccc;
+      padding: 8px;
+      text-align: left;
+    }
+    th {
+      background-color: #e6e6e6;
+    }
+    .titre-section {
+      background: #dcdcdc;
+      padding: 8px;
+      font-weight: bold;
+      text-transform: uppercase;
+    }
+    .totaux {
+      margin-top: 20px;
+      text-align: right;
+    }
+    .conditions, .footer-info {
+      margin-top: 40px;
+      font-size: 0.9em;
+    }
+    .footer-info {
+      display: flex;
+      justify-content: space-between;
+    }
+    .bold {
+      font-weight: bold;
+    }
+    .logo {
+      max-width: 120px;
+      max-height: 80px;
+    }
   </style>
 </head>
-<body class="invoice">
-<header>
-  <img src="<%= logo_path || '/logo.png' %>" alt="Logo">
-  <section class="meta">
-    <h1>FACTURE</h1>
-    <p>N° <%= numero %></p>
-    <p>Date : <%= date %></p>
-  </section>
-</header>
-<section class="addresses">
-  <div class="from">
-    <h2>Émetteur</h2>
-    <%= nom_entreprise %><br>
-    <% if (adresse) { adresse.forEach(l => { %>
-      <%= l %><br>
-    <% }) } %>
+<body>
+  <header>
+    <div>
+      <img src="<%= logoUrl %>" alt="Logo" class="logo" />
+      <div><%= companyName %></div>
+      <div><%= companyAddress %></div>
+      <div><%= companyPostal %></div>
+    </div>
+    <div style="text-align: right;">
+      <div class="bold"><%= clientName %></div>
+      <div><%= clientCompany %></div>
+      <div><%= clientAddress %></div>
+      <div><%= clientPostal %></div>
+    </div>
+  </header>
+
+  <div class="facture-titre" style="margin: 20px 0;">
+    <div class="titre-section">FACTURE</div>
   </div>
-  <div class="to">
-    <h2>Client</h2>
-    <%= nom_client %><br>
-    <% if (adresse_client) { adresse_client.forEach(l => { %>
-      <%= l %><br>
-    <% }) } %>
+
+  <div class="info-client">
+    <div>
+      <div><span class="bold">Numéro de facture :</span> <%= invoiceNumber %></div>
+      <div><span class="bold">Date de facture :</span> <%= invoiceDate %></div>
+      <div><span class="bold">N° client :</span> <%= clientId %></div>
+    </div>
+    <div style="text-align: right;">
+      <%= pageLabel %>
+    </div>
   </div>
-</section>
-<table class="lines">
-  <thead>
-    <tr><th>Description</th><th>Qté</th><th>PU HT</th><th class="price">Total HT</th></tr>
-  </thead>
-  <tbody>
-    <% lignes.forEach(function(l){ %>
+
+  <table>
+    <thead>
       <tr>
-        <td><%= l.description %></td>
-        <td><%= l.quantite %></td>
-        <td class="price"><%= l.prix_unitaire.toFixed(2) %></td>
-        <td class="price"><%= (l.quantite * l.prix_unitaire).toFixed(2) %></td>
+        <th>Description</th>
+        <th>Quantité</th>
+        <th>Unité</th>
+        <th>Prix unitaire HT</th>
+        <th>Total HT</th>
+        <th>TVA</th>
       </tr>
-    <% }) %>
-  </tbody>
-</table>
-<section class="totals">
-  <p>Sous-total HT : <%= totalHT.toFixed(2) %></p>
-  <p>TVA <%= tvaRate %> % : <%= totalTVA.toFixed(2) %></p>
-  <p class="grand">TOTAL TTC : <%= totalTTC.toFixed(2) %></p>
-</section>
-<footer>
-  <p>Conditions de paiement : règlement à réception.</p>
-  <p><%= nom_entreprise %></p>
-</footer>
+    </thead>
+    <tbody>
+      <% items.forEach(function(item){ %>
+      <tr>
+        <td><%= item.description %></td>
+        <td><%= item.quantity %></td>
+        <td><%= item.unit %></td>
+        <td><%= item.unitPrice %> €</td>
+        <td><%= item.totalHt %> €</td>
+        <td><%= item.tva %>%</td>
+      </tr>
+      <% }); %>
+    </tbody>
+  </table>
+
+  <div class="totaux">
+    <table style="width: 50%; float: right;">
+      <% tvaLines.forEach(function(line){ %>
+      <tr>
+        <td>TVA <%= line.rate %> %</td>
+        <td><%= line.tvaAmount %> €</td>
+        <td><%= line.baseHt %> €</td>
+      </tr>
+      <% }); %>
+      <tr>
+        <td class="bold">Total TTC</td>
+        <td colspan="2" class="bold"><%= totalTtc %> €</td>
+      </tr>
+    </table>
+  </div>
+
+  <div class="conditions">
+    <p><%= paymentConditions %></p>
+    <p><%= paymentMethod %></p>
+    <p><%= closingMessage %></p>
+  </div>
+
+  <footer class="footer-info">
+    <div>
+      <p><%= companyFooter %></p>
+      <p><%= companyContact %></p>
+    </div>
+    <div>
+      <p><%= bankDetails %></p>
+      <p><%= legalInfo %></p>
+    </div>
+  </footer>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- modernize invoice html template with professional layout
- map invoice data to the new placeholders
- generate items and VAT lines for pdf export

## Testing
- `pnpm test` in `backend`
- `pnpm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_68584c19e84c832f863a31d83808f0fe