### PR TITLE
Add PDF export option

### DIFF
--- a/frontend/src/pages/DetailFacture.tsx
+++ b/frontend/src/pages/DetailFacture.tsx
@@ -99,18 +99,29 @@ export default function DetailFacture() {
     }
   };
 
-  const telechargerHTML = async () => {
+  const [exportFormat, setExportFormat] = useState<'html' | 'pdf'>('html');
+
+  const telechargerFacture = async () => {
     if (!facture) return;
     try {
-      const response = await fetch(`${API_URL}/factures/${facture.id}/html`);
+      const response = await fetch(
+        `${API_URL}/factures/${facture.id}/${exportFormat}`
+      );
       if (!response.ok) {
         throw new Error('Erreur lors de la génération du fichier');
       }
-      const html = await response.text();
-      const blob = new Blob([html], { type: 'text/html' });
-      saveAs(blob, `facture-${facture.numero_facture}.html`);
+      if (exportFormat === 'pdf') {
+        const pdf = await response.blob();
+        saveAs(pdf, `facture-${facture.numero_facture}.pdf`);
+      } else {
+        const html = await response.text();
+        const blob = new Blob([html], { type: 'text/html' });
+        saveAs(blob, `facture-${facture.numero_facture}.html`);
+      }
     } catch (err) {
-      alert(err instanceof Error ? err.message : 'Erreur lors du téléchargement');
+      alert(
+        err instanceof Error ? err.message : 'Erreur lors du téléchargement'
+      );
     }
   };
 
@@ -204,9 +215,17 @@ export default function DetailFacture() {
                 <Edit className="h-5 w-5 mr-2" />
                 Modifier
               </Link>
+              <select
+                value={exportFormat}
+                onChange={e => setExportFormat(e.target.value as 'html' | 'pdf')}
+                className="px-2 py-2 border border-gray-300 rounded-lg"
+              >
+                <option value="html">HTML</option>
+                <option value="pdf">PDF</option>
+              </select>
               <Button
                 variant="outline"
-                onClick={telechargerHTML}
+                onClick={telechargerFacture}
                 title="Exporter la facture"
               >
                 <Download className="h-5 w-5 mr-2" />

--- a/frontend/src/pages/ListeFactures.tsx
+++ b/frontend/src/pages/ListeFactures.tsx
@@ -43,6 +43,7 @@ export default function ListeFactures() {
   const [statusFilter, setStatusFilter] = useState('');
   const [sortField, setSortField] = useState('date');
   const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('desc');
+  const [exportFormat, setExportFormat] = useState<'html' | 'pdf'>('html');
 
   const chargerFactures = useCallback(async () => {
     try {
@@ -111,16 +112,26 @@ export default function ListeFactures() {
     nomEntreprise?: string
   ) => {
     try {
-      const response = await fetch(`${API_URL}/factures/${id}/html`);
+      const response = await fetch(
+        `${API_URL}/factures/${id}/${exportFormat}`
+      );
       if (!response.ok) {
         throw new Error('Erreur lors de la génération du fichier');
       }
-      const html = await response.text();
-      const blob = new Blob([html], { type: 'text/html' });
-      saveAs(
-        blob,
-        `facture-${numeroFacture}-${dateFacture}-${nomEntreprise ? nomEntreprise.replace(/\s+/g, '-') : ''}.html`
-      );
+      if (exportFormat === 'pdf') {
+        const pdf = await response.blob();
+        saveAs(
+          pdf,
+          `facture-${numeroFacture}-${dateFacture}-${nomEntreprise ? nomEntreprise.replace(/\s+/g, '-') : ''}.pdf`
+        );
+      } else {
+        const html = await response.text();
+        const blob = new Blob([html], { type: 'text/html' });
+        saveAs(
+          blob,
+          `facture-${numeroFacture}-${dateFacture}-${nomEntreprise ? nomEntreprise.replace(/\s+/g, '-') : ''}.html`
+        );
+      }
     } catch (err) {
       alert(err instanceof Error ? err.message : 'Erreur lors du téléchargement');
     }
@@ -251,6 +262,17 @@ export default function ListeFactures() {
             >
               <option value="asc">Croissant</option>
               <option value="desc">Décroissant</option>
+            </select>
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-2">Format export</label>
+            <select
+              value={exportFormat}
+              onChange={(e) => setExportFormat(e.target.value as 'html' | 'pdf')}
+              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
+            >
+              <option value="html">HTML</option>
+              <option value="pdf">PDF</option>
             </select>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- offer HTML/PDF export on invoice details
- add global export format selector for invoice list
- generate PDF via Puppeteer when requested

## Testing
- `cd backend && pnpm install && pnpm test`
- `cd frontend && pnpm install && pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68584e6da154832fa57144f0d108287d