### PR TITLE
Ajout des formulaires clients et upload logo

### DIFF
--- a/backend/database/sqlite.js
+++ b/backend/database/sqlite.js
@@ -25,9 +25,15 @@ class SQLiteDatabase {
     this.db.run(`CREATE TABLE IF NOT EXISTS clients (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
       nom_client TEXT NOT NULL,
+      prenom_client TEXT,
       nom_entreprise TEXT,
       telephone TEXT,
-      adresse TEXT,
+      email TEXT,
+      adresse_facturation TEXT,
+      adresse_livraison TEXT,
+      siret TEXT,
+      tva TEXT,
+      logo TEXT,
       created_at TEXT DEFAULT CURRENT_TIMESTAMP,
       updated_at TEXT DEFAULT CURRENT_TIMESTAMP
     );`);
@@ -73,8 +79,19 @@ class SQLiteDatabase {
   }
 
   createClient(data) {
-    const stmt = this.db.prepare('INSERT INTO clients (nom_client, nom_entreprise, telephone, adresse) VALUES (?,?,?,?)');
-    stmt.run([data.nom_client, data.nom_entreprise || '', data.telephone || '', data.adresse || '']);
+    const stmt = this.db.prepare('INSERT INTO clients (nom_client, prenom_client, nom_entreprise, telephone, email, adresse_facturation, adresse_livraison, siret, tva, logo) VALUES (?,?,?,?,?,?,?,?,?,?)');
+    stmt.run([
+      data.nom_client,
+      data.prenom_client || '',
+      data.nom_entreprise || '',
+      data.telephone || '',
+      data.email || '',
+      data.adresse_facturation || '',
+      data.adresse_livraison || '',
+      data.siret || '',
+      data.tva || '',
+      data.logo || ''
+    ]);
     stmt.free();
     const id = this.db.exec('SELECT last_insert_rowid() AS id')[0].values[0][0];
     this.save();
@@ -82,8 +99,20 @@ class SQLiteDatabase {
   }
 
   updateClient(id, data) {
-    const stmt = this.db.prepare('UPDATE clients SET nom_client=?, nom_entreprise=?, telephone=?, adresse=?, updated_at=CURRENT_TIMESTAMP WHERE id=?');
-    stmt.run([data.nom_client, data.nom_entreprise || '', data.telephone || '', data.adresse || '', id]);
+    const stmt = this.db.prepare('UPDATE clients SET nom_client=?, prenom_client=?, nom_entreprise=?, telephone=?, email=?, adresse_facturation=?, adresse_livraison=?, siret=?, tva=?, logo=?, updated_at=CURRENT_TIMESTAMP WHERE id=?');
+    stmt.run([
+      data.nom_client,
+      data.prenom_client || '',
+      data.nom_entreprise || '',
+      data.telephone || '',
+      data.email || '',
+      data.adresse_facturation || '',
+      data.adresse_livraison || '',
+      data.siret || '',
+      data.tva || '',
+      data.logo || '',
+      id
+    ]);
     const changes = this.db.getRowsModified();
     stmt.free();
     this.save();

--- a/frontend/src/components/LogoDropzone.tsx
+++ b/frontend/src/components/LogoDropzone.tsx
@@ -3,9 +3,10 @@ import { API_URL } from '@/lib/api';
 
 interface Props {
   onUploaded: (path: string) => void;
+  uploadUrl?: string;
 }
 
-export default function LogoDropzone({ onUploaded }: Props) {
+export default function LogoDropzone({ onUploaded, uploadUrl }: Props) {
   const inputRef = useRef<HTMLInputElement>(null);
   const [preview, setPreview] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -29,13 +30,13 @@ export default function LogoDropzone({ onUploaded }: Props) {
     const formData = new FormData();
     formData.append('logo', file);
     try {
-      const res = await fetch(`${API_URL}/upload/logo`, {
+      const res = await fetch(`${API_URL}${uploadUrl || '/upload/logo'}`, {
         method: 'POST',
         body: formData
       });
       if (!res.ok) throw new Error('Upload échoué');
       const data = await res.json();
-      onUploaded(`/uploads/${data.filename}`);
+      onUploaded(data.path || `/uploads/${data.filename}`);
     } catch {
       setError("Erreur lors de l'upload");
     }

--- a/frontend/src/components/clients/CarteClient.tsx
+++ b/frontend/src/components/clients/CarteClient.tsx
@@ -1,0 +1,33 @@
+import { Link } from 'react-router-dom'
+import { Card, CardContent } from '@/components/ui/card'
+
+export interface Client {
+  id: number
+  nom_client: string
+  prenom_client?: string
+  nom_entreprise?: string
+  telephone?: string
+  logo?: string
+  factures: number[]
+}
+
+export default function CarteClient({ client }: { client: Client }) {
+  return (
+    <Card className="p-4 flex flex-col items-center text-center space-y-2">
+      {client.logo && (
+        <img src={client.logo} className="h-16 object-contain" alt={client.nom_client} />
+      )}
+      <div className="font-semibold">
+        {client.prenom_client ? `${client.prenom_client} ${client.nom_client}` : client.nom_client}
+      </div>
+      {client.nom_entreprise && <div>{client.nom_entreprise}</div>}
+      {client.telephone && <div className="text-sm text-gray-500">{client.telephone}</div>}
+      <div className="text-xs text-gray-500">
+        {client.factures ? client.factures.length : 0} facture(s)
+      </div>
+      <Link to={`/clients/${client.id}`} className="text-blue-600 text-sm hover:underline">
+        Voir fiche
+      </Link>
+    </Card>
+  )
+}

--- a/frontend/src/components/clients/FicheClient.tsx
+++ b/frontend/src/components/clients/FicheClient.tsx
@@ -1,0 +1,64 @@
+import { useEffect, useState } from 'react'
+import { useNavigate, useParams, Link } from 'react-router-dom'
+import { API_URL } from '@/lib/api'
+import { Button } from '@/components/ui/button'
+import { Card } from '@/components/ui/card'
+import { Client } from './CarteClient'
+
+export default function FicheClient() {
+  const { id } = useParams<{ id: string }>()
+  const navigate = useNavigate()
+  const [client, setClient] = useState<Client | null>(null)
+
+  useEffect(() => {
+    ;(async () => {
+      const res = await fetch(`${API_URL}/clients/${id}`)
+      if (res.ok) setClient(await res.json())
+    })()
+  }, [id])
+
+  if (!client) return <p>Chargement...</p>
+
+  return (
+    <div className="space-y-4 p-4">
+      <Button variant="outline" onClick={() => navigate(-1)}>
+        Retour
+      </Button>
+      <Card className="p-6 space-y-2">
+        {client.logo && (
+          <img src={client.logo} alt="logo" className="h-20 object-contain" />
+        )}
+        <div className="text-xl font-semibold">
+          {client.prenom_client ? `${client.prenom_client} ${client.nom_client}` : client.nom_client}
+        </div>
+        {client.nom_entreprise && <div>{client.nom_entreprise}</div>}
+        {client.telephone && <div>{client.telephone}</div>}
+        {client.email && <div>{client.email}</div>}
+        {client.adresse_facturation && (
+          <div>
+            <h4 className="font-medium">Adresse de facturation</h4>
+            <p>{client.adresse_facturation}</p>
+          </div>
+        )}
+        {client.adresse_livraison && (
+          <div>
+            <h4 className="font-medium">Adresse de livraison</h4>
+            <p>{client.adresse_livraison}</p>
+          </div>
+        )}
+        {(client.siret || client.tva) && (
+          <div>
+            <h4 className="font-medium">Informations légales</h4>
+            {client.siret && <p>SIRET : {client.siret}</p>}
+            {client.tva && <p>TVA : {client.tva}</p>}
+          </div>
+        )}
+      </Card>
+      {client.factures && client.factures.length > 0 && (
+        <Link to={`/factures?client=${client.id}`} className="text-blue-600 hover:underline">
+          Voir ses factures
+        </Link>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/clients/FormulaireClient.tsx
+++ b/frontend/src/components/clients/FormulaireClient.tsx
@@ -1,0 +1,106 @@
+import { useState, FormEvent } from 'react'
+import LogoDropzone from '@/components/LogoDropzone'
+import { Input } from '@/components/ui/input'
+import { Textarea } from '@/components/ui/textarea'
+import { Label } from '@/components/ui/label'
+import { Button } from '@/components/ui/button'
+import { API_URL } from '@/lib/api'
+
+interface Props {
+  onCreated?: () => void
+}
+
+export default function FormulaireClient({ onCreated }: Props) {
+  const [nom, setNom] = useState('')
+  const [prenom, setPrenom] = useState('')
+  const [entreprise, setEntreprise] = useState('')
+  const [telephone, setTelephone] = useState('')
+  const [email, setEmail] = useState('')
+  const [adresseFact, setAdresseFact] = useState('')
+  const [adresseLiv, setAdresseLiv] = useState('')
+  const [siret, setSiret] = useState('')
+  const [tva, setTva] = useState('')
+  const [logo, setLogo] = useState('')
+
+  const submit = async (e: FormEvent) => {
+    e.preventDefault()
+    if (!nom.trim()) return
+    const res = await fetch(`${API_URL}/clients`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        nom_client: nom,
+        prenom_client: prenom,
+        nom_entreprise: entreprise,
+        telephone,
+        email,
+        adresse_facturation: adresseFact,
+        adresse_livraison: adresseLiv,
+        siret,
+        tva,
+        logo
+      })
+    })
+    if (res.ok) {
+      setNom('')
+      setPrenom('')
+      setEntreprise('')
+      setTelephone('')
+      setEmail('')
+      setAdresseFact('')
+      setAdresseLiv('')
+      setSiret('')
+      setTva('')
+      setLogo('')
+      onCreated?.()
+    }
+  }
+
+  return (
+    <form onSubmit={submit} className="space-y-4">
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div>
+          <Label>Nom *</Label>
+          <Input value={nom} onChange={e => setNom(e.target.value)} />
+        </div>
+        <div>
+          <Label>Prénom</Label>
+          <Input value={prenom} onChange={e => setPrenom(e.target.value)} />
+        </div>
+        <div>
+          <Label>Entreprise</Label>
+          <Input value={entreprise} onChange={e => setEntreprise(e.target.value)} />
+        </div>
+        <div>
+          <Label>Téléphone</Label>
+          <Input value={telephone} onChange={e => setTelephone(e.target.value)} />
+        </div>
+        <div className="md:col-span-2">
+          <Label>Email</Label>
+          <Input value={email} onChange={e => setEmail(e.target.value)} />
+        </div>
+        <div className="md:col-span-2">
+          <Label>Adresse de facturation</Label>
+          <Textarea value={adresseFact} onChange={e => setAdresseFact(e.target.value)} />
+        </div>
+        <div className="md:col-span-2">
+          <Label>Adresse de livraison</Label>
+          <Textarea value={adresseLiv} onChange={e => setAdresseLiv(e.target.value)} />
+        </div>
+        <div>
+          <Label>Numéro SIRET</Label>
+          <Input value={siret} onChange={e => setSiret(e.target.value)} />
+        </div>
+        <div>
+          <Label>Numéro TVA</Label>
+          <Input value={tva} onChange={e => setTva(e.target.value)} />
+        </div>
+        <div className="md:col-span-2">
+          <Label>Logo</Label>
+          <LogoDropzone uploadUrl="/upload/logo-client" onUploaded={setLogo} />
+        </div>
+      </div>
+      <Button type="submit">Ajouter</Button>
+    </form>
+  )
+}

--- a/frontend/src/components/clients/ListeClients.tsx
+++ b/frontend/src/components/clients/ListeClients.tsx
@@ -1,0 +1,51 @@
+import { useEffect, useState } from 'react'
+import FormulaireClient from './FormulaireClient'
+import CarteClient, { Client } from './CarteClient'
+import { Input } from '@/components/ui/input'
+import { API_URL } from '@/lib/api'
+
+export default function ListeClients() {
+  const [clients, setClients] = useState<Client[]>([])
+  const [search, setSearch] = useState('')
+
+  const load = async () => {
+    const res = await fetch(`${API_URL}/clients`)
+    if (res.ok) {
+      const data = await res.json()
+      setClients(data)
+    }
+  }
+
+  useEffect(() => {
+    load()
+  }, [])
+
+  const filtered = clients.filter(c => {
+    const term = search.toLowerCase()
+    return (
+      c.nom_client.toLowerCase().includes(term) ||
+      (c.prenom_client && c.prenom_client.toLowerCase().includes(term)) ||
+      (c.nom_entreprise && c.nom_entreprise.toLowerCase().includes(term)) ||
+      (c.telephone && c.telephone.toLowerCase().includes(term))
+    )
+  })
+
+  return (
+    <div className="space-y-6">
+      <Input
+        placeholder="Rechercher..."
+        value={search}
+        onChange={e => setSearch(e.target.value)}
+        className="max-w-sm"
+      />
+      <div className="grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
+        <div className="p-4 border rounded">
+          <FormulaireClient onCreated={load} />
+        </div>
+        {filtered.map(c => (
+          <CarteClient key={c.id} client={c} />
+        ))}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- ajout du stockage de logo client et nouvelles informations dans la base SQLite
- nouvelle API pour uploader un logo de client
- extension des routes POST/PUT clients
- amélioration de `LogoDropzone` pour accepter une URL d'upload
- nouveaux composants React pour gérer les clients (formulaire, cartes, liste et fiche)

## Testing
- `cd backend && pnpm install && pnpm test`
- `cd frontend && pnpm install && pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68585151d5e4832f9da463cdd2454a60