### PR TITLE
Add interactive stats widget

### DIFF
--- a/frontend/src/components/cards/StatsCarousel.tsx
+++ b/frontend/src/components/cards/StatsCarousel.tsx
@@ -1,0 +1,123 @@
+import { useEffect, useState, useMemo } from 'react';
+import { Link } from 'react-router-dom';
+import {
+  Carousel,
+  CarouselContent,
+  CarouselItem,
+  CarouselPrevious,
+  CarouselNext,
+  type CarouselApi,
+} from '@/components/ui/carousel';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { InvoicePieChart } from './InvoicePieChart';
+import { API_URL } from '@/lib/api';
+
+interface Facture {
+  montant_total: number;
+}
+
+export function StatsCarousel() {
+  const [api, setApi] = useState<CarouselApi>();
+  const [index, setIndex] = useState(0);
+  const [pieStats, setPieStats] = useState({ paid: 0, unpaid: 0 });
+  const [unpaid, setUnpaid] = useState<Facture[]>([]);
+
+  const euro = useMemo(
+    () =>
+      new Intl.NumberFormat('fr-FR', { style: 'currency', currency: 'EUR' }),
+    []
+  );
+
+  useEffect(() => {
+    async function loadPie() {
+      try {
+        const r = await fetch(`${API_URL}/invoices?month=current`);
+        if (r.ok) {
+          setPieStats(await r.json());
+        }
+      } catch {
+        /* ignore */
+      }
+    }
+    async function loadUnpaid() {
+      try {
+        const r = await fetch(`${API_URL}/factures?status=unpaid&limit=1000`);
+        if (r.ok) {
+          const d = await r.json();
+          setUnpaid(d.factures || []);
+        }
+      } catch {
+        /* ignore */
+      }
+    }
+    loadPie();
+    loadUnpaid();
+  }, []);
+
+  useEffect(() => {
+    if (!api) return;
+    const onSelect = () => setIndex(api.selectedScrollSnap());
+    api.on('select', onSelect);
+    onSelect();
+    return () => {
+      api.off('select', onSelect);
+    };
+  }, [api]);
+
+  const unpaidTotal = useMemo(
+    () => unpaid.reduce((sum, f) => sum + (f.montant_total || 0), 0),
+    [unpaid]
+  );
+
+  const invoicesThisMonth = pieStats.paid + pieStats.unpaid;
+
+  return (
+    <div className="w-full">
+      <Carousel setApi={setApi} className="w-full">
+        <CarouselContent>
+          <CarouselItem>
+            <Link to="/factures?status=unpaid" className="block">
+              <InvoicePieChart />
+            </Link>
+          </CarouselItem>
+          <CarouselItem>
+            <Card>
+              <CardHeader>
+                <CardTitle>Paiements en attente</CardTitle>
+              </CardHeader>
+              <CardContent className="text-center">
+                <p className="text-3xl font-bold">
+                  {euro.format(unpaidTotal)}
+                </p>
+              </CardContent>
+            </Card>
+          </CarouselItem>
+          <CarouselItem>
+            <Card>
+              <CardHeader>
+                <CardTitle>Factures générées ce mois-ci</CardTitle>
+              </CardHeader>
+              <CardContent className="text-center">
+                <p className="text-3xl font-bold">{invoicesThisMonth}</p>
+              </CardContent>
+            </Card>
+          </CarouselItem>
+        </CarouselContent>
+        <CarouselPrevious className="-left-4" />
+        <CarouselNext className="-right-4" />
+      </Carousel>
+      <div className="flex justify-center mt-2 space-x-2">
+        {[0, 1, 2].map(i => (
+          <span
+            key={i}
+            className={`h-2 w-2 rounded-full ${
+              i === index
+                ? 'bg-indigo-600'
+                : 'bg-gray-300 dark:bg-gray-600'
+            }`}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/cards/index.ts
+++ b/frontend/src/components/cards/index.ts
@@ -4,3 +4,4 @@ export * from './InvoicePieChart';
 export * from './ApiInfoCard';
 export * from './QuoteCard';
 export * from './SunsetImageCard';
+export * from './StatsCarousel';

--- a/frontend/src/pages/Accueil.tsx
+++ b/frontend/src/pages/Accueil.tsx
@@ -4,7 +4,7 @@ import { FileText, Plus, BarChart3, Users } from 'lucide-react';
 import {
   QuoteCard,
   SunsetImageCard,
-  InvoicePieChart,
+  StatsCarousel,
 } from '@/components/cards';
 
 export default function Accueil() {
@@ -51,7 +51,7 @@ export default function Accueil() {
       <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 mb-12">
         <QuoteCard />
         <SunsetImageCard />
-        <InvoicePieChart />
+        <StatsCarousel />
       </div>
 
         {/* Action Cards */}


### PR DESCRIPTION
## Summary
- add `StatsCarousel` card to show stats in a carousel
- expose new card from components index
- replace `InvoicePieChart` with `StatsCarousel` on the homepage

## Testing
- `cd backend && pnpm test`
- `cd frontend && pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68587f8a91d4832fb6376d200094948d