### PR TITLE
Improve mobile theme and sidebar navigation

### DIFF
--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -31,10 +31,6 @@ export default function Sidebar() {
           <FileText className="h-5 w-5" />
           <span>Toutes les factures</span>
         </NavLink>
-        <NavLink to="/factures/nouvelle" className="flex items-center space-x-2 hover:text-primary">
-          <PlusCircle className="h-5 w-5" />
-          <span>Créer une facture</span>
-        </NavLink>
         <NavLink to="/factures?status=unpaid" className="flex items-center space-x-2 hover:text-primary">
           <CircleAlert className="h-5 w-5" />
           <span>Factures non payées</span>
@@ -43,15 +39,21 @@ export default function Sidebar() {
           <CircleAlert className="h-5 w-5" />
           <span>Factures payées</span>
         </NavLink>
+        <NavLink to="/factures/nouvelle" className="flex items-center space-x-2 hover:text-primary">
+          <PlusCircle className="h-5 w-5" />
+          <span>Créer une facture</span>
+        </NavLink>
         <NavLink to="/clients" className="flex items-center space-x-2 hover:text-primary">
           <Users className="h-5 w-5" />
           <span>Clients</span>
         </NavLink>
+      </nav>
+      <div className="mt-8">
         <button onClick={toggleTheme} className="flex items-center space-x-2 hover:text-primary">
           <Sun className="h-5 w-5" />
           <span>Changer le thème ({theme})</span>
         </button>
-      </nav>
+      </div>
     </aside>
   )
 

--- a/frontend/src/components/ui/command.tsx
+++ b/frontend/src/components/ui/command.tsx
@@ -42,7 +42,7 @@ const CommandInput = React.forwardRef<
     <CommandPrimitive.Input
       ref={ref}
       className={cn(
-        "flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-none placeholder:text-zinc-500 disabled:cursor-not-allowed disabled:opacity-50 dark:placeholder:text-zinc-400",
+        "flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-none placeholder-[#555] disabled:cursor-not-allowed disabled:opacity-50 dark:placeholder-[#555]",
         className
       )}
       {...props}

--- a/frontend/src/components/ui/input.tsx
+++ b/frontend/src/components/ui/input.tsx
@@ -8,7 +8,7 @@ const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
       <input
         type={type}
         className={cn(
-          "flex h-9 w-full rounded-md border border-zinc-200 bg-transparent px-3 py-1 text-base shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-zinc-950 placeholder:text-zinc-500 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-zinc-950 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm dark:border-zinc-800 dark:file:text-zinc-50 dark:placeholder:text-zinc-400 dark:focus-visible:ring-zinc-300",
+          "flex h-9 w-full rounded-md border border-zinc-200 bg-transparent px-3 py-1 text-base shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-zinc-950 placeholder-[#555] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-zinc-950 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm dark:border-zinc-800 dark:file:text-zinc-50 dark:placeholder-[#555] dark:focus-visible:ring-zinc-300",
           className
         )}
         ref={ref}

--- a/frontend/src/components/ui/select.tsx
+++ b/frontend/src/components/ui/select.tsx
@@ -19,7 +19,7 @@ const SelectTrigger = React.forwardRef<
   <SelectPrimitive.Trigger
     ref={ref}
     className={cn(
-      "flex h-9 w-full items-center justify-between whitespace-nowrap rounded-md border border-zinc-200 bg-transparent px-3 py-2 text-sm shadow-sm ring-offset-white placeholder:text-zinc-500 focus:outline-none focus:ring-1 focus:ring-zinc-950 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1 dark:border-zinc-800 dark:ring-offset-zinc-950 dark:placeholder:text-zinc-400 dark:focus:ring-zinc-300",
+      "flex h-9 w-full items-center justify-between whitespace-nowrap rounded-md border border-zinc-200 bg-transparent px-3 py-2 text-sm shadow-sm ring-offset-white placeholder-[#555] focus:outline-none focus:ring-1 focus:ring-zinc-950 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1 dark:border-zinc-800 dark:ring-offset-zinc-950 dark:placeholder-[#555] dark:focus:ring-zinc-300",
       className
     )}
     {...props}

--- a/frontend/src/components/ui/textarea.tsx
+++ b/frontend/src/components/ui/textarea.tsx
@@ -9,7 +9,7 @@ const Textarea = React.forwardRef<
   return (
     <textarea
       className={cn(
-        "flex min-h-[60px] w-full rounded-md border border-zinc-200 bg-transparent px-3 py-2 text-base shadow-sm placeholder:text-zinc-500 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-zinc-950 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm dark:border-zinc-800 dark:placeholder:text-zinc-400 dark:focus-visible:ring-zinc-300",
+        "flex min-h-[60px] w-full rounded-md border border-zinc-200 bg-transparent px-3 py-2 text-base shadow-sm placeholder-[#555] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-zinc-950 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm dark:border-zinc-800 dark:placeholder-[#555] dark:focus-visible:ring-zinc-300",
         className
       )}
       ref={ref}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -46,7 +46,10 @@
   }
 
   html.mobile {
-    --background: #111111;
+    --background: #121212;
+    --foreground: #FFD369;
+    --sidebar-background: 0 0% 8%;
+    --sidebar-foreground: 45 96% 65%;
     --gradient-start: #ff6a85;
     --gradient-end: #ffb26b;
   }
@@ -88,7 +91,7 @@ html.dark body {
 }
 
 html.mobile body {
-  background-color: #111111;
+  background-color: #121212;
   color: var(--foreground);
 }
 
@@ -118,5 +121,20 @@ body.app-fade {
 
   .hover-glow:hover {
     box-shadow: 0 0 15px rgba(255, 173, 128, 0.6);
+  }
+
+  input::placeholder,
+  textarea::placeholder,
+  select::placeholder {
+    color: #555;
+  }
+
+  html.mobile button {
+    border-color: #FFD369;
+  }
+
+  html.mobile button:hover,
+  html.mobile button:active {
+    box-shadow: 0 0 10px rgba(255, 211, 105, 0.6);
   }
 }


### PR DESCRIPTION
## Summary
- reorder sidebar links and move theme toggle to bottom
- tweak the mobile theme colors for stronger contrast
- ensure placeholders use a dark gray
- highlight buttons and inputs on mobile

## Testing
- `cd backend && pnpm install && pnpm test`
- `cd frontend && pnpm install && pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_685884567344832f97a2130c25bfbf97