### PR TITLE
Add startup internet connection check

### DIFF
--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -3,6 +3,9 @@ import { createRoot } from 'react-dom/client'
 import { ErrorBoundary } from './components/ErrorBoundary.tsx'
 import './index.css'
 import App from './App.tsx'
+import { checkInternetConnection } from './utils/network.ts'
+
+checkInternetConnection()
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/frontend/src/utils/network.ts
+++ b/frontend/src/utils/network.ts
@@ -1,0 +1,24 @@
+export async function checkInternetConnection() {
+  if (typeof navigator !== 'undefined' && !navigator.onLine) {
+    alert('Aucune connexion Internet détectée – certaines fonctionnalités peuvent ne pas fonctionner');
+    return false;
+  }
+  try {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 3000);
+    const response = await fetch('https://clients3.google.com/generate_204', {
+      method: 'GET',
+      cache: 'no-cache',
+      signal: controller.signal,
+    });
+    clearTimeout(timeout);
+    if (response.ok) {
+      console.log('Connexion Internet détectée');
+      return true;
+    }
+    throw new Error('Network response was not ok');
+  } catch (_err) {
+    alert('Aucune connexion Internet détectée – certaines fonctionnalités peuvent ne pas fonctionner');
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary
- add helper to detect internet connectivity
- call `checkInternetConnection()` when the frontend starts

## Testing
- `cd backend && pnpm install && pnpm test`
- `cd frontend && pnpm install && pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_685887206eb0832fa56553f745de08de