### PR TITLE
Add PDF export test

### DIFF
--- a/backend/tests/exportPdf.test.js
+++ b/backend/tests/exportPdf.test.js
@@ -1,0 +1,42 @@
+const request = require('supertest');
+
+jest.mock('puppeteer', () => ({
+  launch: async () => ({
+    newPage: async () => ({
+      setContent: jest.fn(),
+      pdf: jest.fn().mockResolvedValue(Buffer.from('PDFDATA'))
+    }),
+    close: jest.fn()
+  })
+}));
+
+let app;
+
+beforeAll(async () => {
+  app = await require('../server');
+});
+
+describe('GET /api/factures/:id/pdf', () => {
+  test('returns invoice PDF', async () => {
+    const createRes = await request(app)
+      .post('/api/factures')
+      .send({
+        nom_client: 'Client Test',
+        date_facture: '2024-01-01',
+        lignes: [{ description: 'Item', quantite: 1, prix_unitaire: 10 }]
+      });
+    expect(createRes.status).toBe(201);
+    const id = createRes.body.id;
+
+    const res = await request(app).get(`/api/factures/${id}/pdf`);
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toMatch(/application\/pdf/);
+    expect(res.body.length).toBeGreaterThan(0);
+  });
+
+  test('returns 404 for missing invoice', async () => {
+    const res = await request(app).get('/api/factures/9999/pdf');
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe('Facture non trouvée');
+  });
+});


### PR DESCRIPTION
## Summary
- add regression test for the `/api/factures/:id/pdf` endpoint

## Testing
- `pnpm test` in `backend`
- `pnpm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_685889794b50832fb5f0320d97b7c0f9