### PR TITLE
Fix PDF generation and add standalone test

### DIFF
--- a/backend/data/test-invoice.json
+++ b/backend/data/test-invoice.json
@@ -1,0 +1,12 @@
+{
+  "nom_client": "Client Test",
+  "nom_entreprise": "Entreprise Test",
+  "adresse": "123 Rue de Test\n75000 Paris",
+  "date_facture": "2024-01-01",
+  "numero_facture": "2024-001",
+  "vat_rate": 20,
+  "lignes": [
+    { "description": "Item A", "quantite": 2, "prix_unitaire": 10 },
+    { "description": "Item B", "quantite": 1, "prix_unitaire": 20 }
+  ]
+}

--- a/backend/pdf/generatePdf.js
+++ b/backend/pdf/generatePdf.js
@@ -1,0 +1,19 @@
+const puppeteer = require('puppeteer');
+
+async function generatePdf(html) {
+  try {
+    const browser = await puppeteer.launch({
+      args: ['--no-sandbox', '--disable-setuid-sandbox']
+    });
+    const page = await browser.newPage();
+    await page.setContent(html, { waitUntil: 'networkidle0' });
+    const pdfBuffer = await page.pdf({ format: 'A4' });
+    await browser.close();
+    return pdfBuffer;
+  } catch (err) {
+    console.error('PDF generation error:', err);
+    throw err;
+  }
+}
+
+module.exports = generatePdf;

--- a/backend/pdfTest.js
+++ b/backend/pdfTest.js
@@ -1,0 +1,19 @@
+const fs = require('fs');
+const path = require('path');
+const buildFactureHTML = require('./services/htmlService');
+const generatePdf = require('./pdf/generatePdf');
+
+async function main() {
+  try {
+    const dataPath = path.join(__dirname, 'data', 'test-invoice.json');
+    const facture = JSON.parse(fs.readFileSync(dataPath, 'utf8'));
+    const html = buildFactureHTML(facture);
+    const pdfBuffer = await generatePdf(html);
+    fs.writeFileSync(path.join(__dirname, 'test-invoice.pdf'), pdfBuffer);
+    console.log('PDF generated at', path.join(__dirname, 'test-invoice.pdf'));
+  } catch (err) {
+    console.error('PDF generation failed:', err);
+  }
+}
+
+main();

--- a/backend/server.js
+++ b/backend/server.js
@@ -6,6 +6,7 @@ const path = require('path');
 const fs = require('fs');
 const multer = require('multer');
 const buildFactureHTML = require('./services/htmlService');
+const generatePdf = require('./pdf/generatePdf');
 const SQLiteDatabase = require('./database/sqlite');
 const { computeTotals } = require('./utils/computeTotals.ts');
 const { getRandomQuote } = require('./services/quoteService');
@@ -600,16 +601,15 @@ app.get('/api/factures/:id/pdf', async (req, res) => {
   }
   try {
     const html = buildFactureHTML(facture);
-    const puppeteer = require('puppeteer');
-    const browser = await puppeteer.launch();
-    const page = await browser.newPage();
-    await page.setContent(html, { waitUntil: 'networkidle0' });
-    const pdf = await page.pdf({ format: 'A4' });
-    await browser.close();
+    const pdf = await generatePdf(html);
     res.setHeader('Content-Type', 'application/pdf');
     res.send(pdf);
   } catch (err) {
-    res.status(500).json({ error: 'Erreur lors de la génération du PDF' });
+    console.error('Error generating PDF for invoice:', err);
+    res.status(500).json({
+      error: 'Erreur lors de la génération du PDF',
+      details: err.message,
+    });
   }
 });
 


### PR DESCRIPTION
## Summary
- extract PDF creation to `pdf/generatePdf.js`
- add sandbox flags and error logging
- refactor server to use new helper
- provide sample invoice and standalone `pdfTest.js`

## Testing
- `pnpm install` & `pnpm test` in `backend`
- `pnpm install` & `pnpm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_68589d201c48832f9344901fb4615223