### PR TITLE
Improve puppeteer logging and pdf route debug

### DIFF
--- a/backend/pdf/generatePdf.js
+++ b/backend/pdf/generatePdf.js
@@ -1,16 +1,33 @@
 const puppeteer = require('puppeteer');
+const fs = require('fs');
+const path = require('path');
 
 async function generatePdf(html) {
+  console.log('HTML source reçu:', html);
+  let browser;
   try {
-    const browser = await puppeteer.launch({
-      args: ['--no-sandbox', '--disable-setuid-sandbox']
-    });
+    try {
+      browser = await puppeteer.launch();
+    } catch (initialErr) {
+      console.warn('Default launch failed, retrying with sandbox disabled:', initialErr.message);
+      browser = await puppeteer.launch({ headless: 'new', args: ['--no-sandbox', '--disable-setuid-sandbox'] });
+    }
+
+    const outputDir = path.join(__dirname, 'output');
+    try {
+      fs.mkdirSync(outputDir, { recursive: true });
+      fs.accessSync(outputDir, fs.constants.W_OK);
+    } catch (dirErr) {
+      console.warn('Write access check failed for', outputDir, dirErr.message);
+    }
+
     const page = await browser.newPage();
     await page.setContent(html, { waitUntil: 'networkidle0' });
     const pdfBuffer = await page.pdf({ format: 'A4' });
     await browser.close();
     return pdfBuffer;
   } catch (err) {
+    if (browser) await browser.close();
     console.error('PDF generation error:', err);
     throw err;
   }

--- a/backend/server.js
+++ b/backend/server.js
@@ -601,6 +601,7 @@ app.get('/api/factures/:id/pdf', async (req, res) => {
   }
   try {
     const html = buildFactureHTML(facture);
+    console.log('Payload reçu :', html);
     const pdf = await generatePdf(html);
     res.setHeader('Content-Type', 'application/pdf');
     res.send(pdf);


### PR DESCRIPTION
## Summary
- add fallback launch and HTML logging to pdf generator
- log payload before pdf generation in API

## Testing
- `cd backend && pnpm install && pnpm test --silent`
- `cd frontend && pnpm install && pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68589e53c18c832fa45d0297ba72c27c