### PR TITLE
Add PDF export debugging logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ backend/dist/
 backend/database/*.sqlite
 backend/uploads/*
 !backend/uploads/.gitkeep
+backend/last-facture.html

--- a/backend/pdf/generatePdf.js
+++ b/backend/pdf/generatePdf.js
@@ -3,7 +3,7 @@ const fs = require('fs');
 const path = require('path');
 
 async function generatePdf(html) {
-  console.log('HTML source reçu:', html);
+  console.log('[HTML ENTRANT DANS Puppeteer]:', html.slice(0, 500));
   let browser;
   try {
     try {

--- a/backend/server.js
+++ b/backend/server.js
@@ -600,8 +600,9 @@ app.get('/api/factures/:id/pdf', async (req, res) => {
     return res.status(404).json({ error: 'Facture non trouvée' });
   }
   try {
+    console.log('Facture reçue pour export :', facture);
     const html = buildFactureHTML(facture);
-    console.log('Payload reçu :', html);
+    fs.writeFileSync('last-facture.html', html, 'utf-8');
     const pdf = await generatePdf(html);
     res.setHeader('Content-Type', 'application/pdf');
     res.send(pdf);

--- a/backend/services/htmlService.js
+++ b/backend/services/htmlService.js
@@ -85,7 +85,12 @@ function buildFactureHTML(facture) {
 
   const templatePath = path.join(__dirname, '..', 'views', 'invoice.ejs');
   const template = fs.readFileSync(templatePath, 'utf8');
-  return ejs.render(template, templateData);
+  try {
+    return ejs.render(template, templateData);
+  } catch (err) {
+    console.error('Erreur lors du rendu du template:', err);
+    throw err;
+  }
 }
 
 module.exports = buildFactureHTML;


### PR DESCRIPTION
## Summary
- log incoming PDF HTML source in `generatePdf`
- catch template rendering errors in `buildFactureHTML`
- write out latest HTML and log invoice object when exporting PDF
- ignore generated `last-facture.html`

## Testing
- `cd backend && pnpm test`
- `cd frontend && pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6858a17d04a0832f8475c021eb268764