### PR TITLE
Add env var and logs for facture download

### DIFF
--- a/frontend/.env
+++ b/frontend/.env
@@ -1,0 +1,1 @@
+VITE_API_URL=http://localhost:3001/api

--- a/frontend/src/pages/DetailFacture.tsx
+++ b/frontend/src/pages/DetailFacture.tsx
@@ -105,6 +105,8 @@ export default function DetailFacture() {
   ): Promise<void> => {
     if (!facture) return;
     try {
+      console.log('API_URL', API_URL);
+      console.log('Téléchargement de la facture', facture?.id, format);
       const response = await fetch(
         `${API_URL}/factures/${facture.id}/${format}`
       );

--- a/frontend/src/pages/ListeFactures.tsx
+++ b/frontend/src/pages/ListeFactures.tsx
@@ -132,6 +132,8 @@ export default function ListeFactures() {
     format: 'html' | 'pdf' = exportFormat
   ): Promise<void> => {
     try {
+      console.log('API_URL', API_URL);
+      console.log('Téléchargement de la facture', id, format);
       const response = await fetch(`${API_URL}/factures/${id}/${format}`);
       if (!response.ok) {
         throw new Error('Erreur lors de la génération du fichier');


### PR DESCRIPTION
## Summary
- add `.env` for the frontend with `VITE_API_URL`
- log API URL and invoice id when downloading invoices

## Testing
- `cd backend && pnpm install && pnpm test`
- `cd frontend && pnpm install && pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6858a4d9cc58832f8ef2b76b43c4ab8b