### PR TITLE
Add invoice status update tests

### DIFF
--- a/backend/tests/status.test.js
+++ b/backend/tests/status.test.js
@@ -1,0 +1,30 @@
+const request = require('supertest');
+let app;
+
+beforeAll(async () => {
+  app = await require('../server');
+});
+
+describe('PATCH /api/factures/:id/status', () => {
+  test('updates invoice status', async () => {
+    const createRes = await request(app)
+      .post('/api/factures')
+      .send({
+        nom_client: 'Client Test',
+        date_facture: '2024-01-01',
+        lignes: [{ description: 'Item', quantite: 1, prix_unitaire: 10 }]
+      });
+    expect(createRes.status).toBe(201);
+    const id = createRes.body.id;
+
+    const patchRes = await request(app)
+      .patch(`/api/factures/${id}/status`)
+      .send({ status: 'paid' });
+    expect(patchRes.status).toBe(200);
+    expect(patchRes.body.message).toBe('Statut mis à jour');
+
+    const getRes = await request(app).get(`/api/factures/${id}`);
+    expect(getRes.status).toBe(200);
+    expect(getRes.body.status).toBe('paid');
+  });
+});

--- a/frontend/src/pages/ListeFactures.test.tsx
+++ b/frontend/src/pages/ListeFactures.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { BrowserRouter } from 'react-router-dom';
+import ListeFactures from './ListeFactures';
+
+const facturesResponse = {
+  factures: [
+    {
+      id: 1,
+      numero_facture: 'F001',
+      nom_client: 'Test',
+      date_facture: '2024-01-01',
+      date_facture_fr: '01/01/2024',
+      montant_total: 10,
+      montant_total_fr: '10€',
+      nombre_lignes: 1,
+      status: 'unpaid'
+    }
+  ],
+  pagination: { page: 1, limit: 10, total: 1, totalPages: 1 }
+};
+
+global.fetch = jest
+  .fn()
+  .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(facturesResponse) })
+  .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ message: 'Statut mis à jour' }) });
+
+test('marque une facture comme payée', async () => {
+  render(
+    <BrowserRouter>
+      <ListeFactures />
+    </BrowserRouter>
+  );
+  await waitFor(() => expect(fetch as any).toHaveBeenCalled());
+
+  const btn = await screen.findByTitle('Marquer comme payée');
+  fireEvent.click(btn);
+
+  await waitFor(() =>
+    expect(fetch as any).toHaveBeenCalledWith(
+      expect.stringContaining('/status'),
+      expect.objectContaining({ method: 'PATCH' })
+    )
+  );
+});


### PR DESCRIPTION
## Summary
- add backend test for PATCH /api/factures/:id/status
- add frontend test for marking an invoice as paid

## Testing
- `pnpm test` in `backend`
- `pnpm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_6858a4646f14832f8927206a4b5f1f5d