### PR TITLE
Improve layout and card styling

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -44,9 +44,9 @@ function App() {
     <ErrorBoundary>
       <ThemeProvider>
         <Router>
-          <div className="flex">
+          <div className="flex h-screen">
             <Sidebar />
-            <main className="ml-64 flex-1 min-h-screen p-0">
+            <main className="flex-1 px-4 py-6 overflow-auto">
               <AnimatedRoutes />
             </main>
           </div>

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -16,7 +16,7 @@ export default function Sidebar() {
 
   const sidebar = (
     <aside
-      className={`fixed left-0 top-0 z-50 h-full w-64 bg-sidebar p-6 text-sidebar-foreground shadow-lg transform transition-transform md:translate-x-0 ${open ? 'translate-x-0' : '-translate-x-full'} relative`}
+      className={`${isMobile ? 'fixed left-0 top-0 z-50 h-full' : ''} w-56 min-w-[14rem] border-r border-gray-200 bg-white shadow-sm p-4 flex flex-col justify-between transition-all duration-300 transform md:translate-x-0 ${open ? 'translate-x-0' : '-translate-x-full'}`}
     >
       {isMobile && (
         <button onClick={() => setOpen(false)} className="absolute top-2 right-2 p-1">

--- a/frontend/src/components/cards/QuoteCard.tsx
+++ b/frontend/src/components/cards/QuoteCard.tsx
@@ -25,11 +25,11 @@ export function QuoteCard() {
   }, []);
 
   return (
-    <Card>
-      <CardHeader>
-        <CardTitle>Citation du jour</CardTitle>
-      </CardHeader>
-      <CardContent>
+    <div className="rounded-xl shadow-md bg-white p-6 transition-all duration-300">
+      <div className="mb-4">
+        <h3 className="font-semibold">Citation du jour</h3>
+      </div>
+      <div>
         {quote ? (
           <motion.blockquote
             initial={{ opacity: 0, y: 10 }}
@@ -56,8 +56,8 @@ export function QuoteCard() {
         ) : (
           <Skeleton className="h-20 w-full" />
         )}
-      </CardContent>
-    </Card>
+      </div>
+    </div>
   );
 }
 

--- a/frontend/src/components/cards/StatsCarousel.tsx
+++ b/frontend/src/components/cards/StatsCarousel.tsx
@@ -72,7 +72,7 @@ export function StatsCarousel() {
   const invoicesThisMonth = pieStats.paid + pieStats.unpaid;
 
   return (
-    <div className="w-full">
+    <div className="rounded-xl shadow-md bg-white p-6 transition-all duration-300 w-full">
       <Carousel setApi={setApi} className="w-full">
         <CarouselContent>
           <CarouselItem>

--- a/frontend/src/components/cards/SunsetImageCard.tsx
+++ b/frontend/src/components/cards/SunsetImageCard.tsx
@@ -23,11 +23,11 @@ export function SunsetImageCard() {
   }, []);
 
   return (
-    <Card>
-      <CardHeader>
-        <CardTitle>Coucher de soleil</CardTitle>
-      </CardHeader>
-      <CardContent>
+    <div className="rounded-xl shadow-md bg-white p-6 transition-all duration-300 animate-fade-in">
+      <div className="mb-4">
+        <h3 className="font-semibold">Coucher de soleil</h3>
+      </div>
+      <div>
         {img ? (
           <motion.img
             key={img}
@@ -41,7 +41,7 @@ export function SunsetImageCard() {
         ) : (
           <Skeleton className="h-40 w-full" />
         )}
-      </CardContent>
-    </Card>
+      </div>
+    </div>
   );
 }

--- a/frontend/src/pages/Accueil.tsx
+++ b/frontend/src/pages/Accueil.tsx
@@ -48,7 +48,7 @@ export default function Accueil() {
         </p>
       </div>
 
-      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 mb-12">
+      <div className="max-w-7xl mx-auto grid grid-cols-1 md:grid-cols-3 gap-6 mt-8">
         <QuoteCard />
         <SunsetImageCard />
         <StatsCarousel />


### PR DESCRIPTION
## Summary
- adjust layout container and main area
- style sidebar with border and transition
- wrap homepage cards in responsive grid container
- unify QuoteCard, SunsetImageCard, StatsCarousel styles

## Testing
- `cd backend && pnpm test`
- `cd frontend && pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6858abb6b004832f9f0ac6b532213eff