### PR TITLE
Add TopBar and mobile sidebar improvements

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -11,6 +11,9 @@ import ClientProfile from './pages/profiles/ClientProfile'
 import NotFound from './pages/Error/NotFound'
 import { ErrorBoundary } from './components/ErrorBoundary'
 import Sidebar from './components/Sidebar'
+import TopBar from './components/TopBar'
+import { useState, useEffect } from 'react'
+import { useIsMobile } from './hooks/use-mobile'
 import { ThemeProvider } from './context/ThemeContext'
 
 function AnimatedRoutes() {
@@ -40,15 +43,25 @@ function AnimatedRoutes() {
 }
 
 function App() {
+  const isMobile = useIsMobile()
+  const [sidebarOpen, setSidebarOpen] = useState(!isMobile)
+
+  useEffect(() => {
+    setSidebarOpen(!isMobile)
+  }, [isMobile])
+
   return (
     <ErrorBoundary>
       <ThemeProvider>
         <Router>
-          <div className="flex h-screen">
-            <Sidebar />
-            <main className="flex-1 px-4 py-6 overflow-auto">
-              <AnimatedRoutes />
-            </main>
+          <div className="flex h-screen overflow-hidden">
+            <Sidebar open={sidebarOpen} setOpen={setSidebarOpen} />
+            <div className="flex flex-col flex-1">
+              <TopBar onMenuClick={() => setSidebarOpen(true)} />
+              <main className="flex-1 overflow-auto pt-16 px-4 py-6">
+                <AnimatedRoutes />
+              </main>
+            </div>
           </div>
         </Router>
       </ThemeProvider>

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -1,18 +1,18 @@
 import { NavLink } from 'react-router-dom'
-import { Home, FileText, PlusCircle, CircleAlert, Sun, Users, Menu, X, LogOut } from 'lucide-react'
+import { Home, FileText, PlusCircle, CircleAlert, Sun, Users, X, LogOut } from 'lucide-react'
 import { useTheme } from '../context/ThemeContext'
 import { useIsMobile } from '../hooks/use-mobile'
-import { useState, useEffect } from 'react'
+
 import { handleQuitApp } from '../utils/system'
 
-export default function Sidebar() {
+interface SidebarProps {
+  open: boolean
+  setOpen: (open: boolean) => void
+}
+
+export default function Sidebar({ open, setOpen }: SidebarProps) {
   const { theme, toggleTheme } = useTheme()
   const isMobile = useIsMobile()
-  const [open, setOpen] = useState(!isMobile)
-
-  useEffect(() => {
-    setOpen(!isMobile)
-  }, [isMobile])
 
   const sidebar = (
     <aside
@@ -70,14 +70,6 @@ export default function Sidebar() {
 
   return (
     <>
-      {isMobile && !open && (
-        <button
-          onClick={() => setOpen(true)}
-          className="fixed top-2 left-2 z-40 p-2 bg-sidebar text-sidebar-foreground rounded-md shadow md:hidden"
-        >
-          <Menu className="h-5 w-5" />
-        </button>
-      )}
       {isMobile && open && (
         <div className="fixed inset-0 z-30 bg-black/50" onClick={() => setOpen(false)} />
       )}

--- a/frontend/src/components/TopBar.tsx
+++ b/frontend/src/components/TopBar.tsx
@@ -1,0 +1,29 @@
+import { Menu, Home } from 'lucide-react'
+import { useNavigate } from 'react-router-dom'
+import { useIsMobile } from '../hooks/use-mobile'
+
+interface TopBarProps {
+  onMenuClick: () => void
+}
+
+export default function TopBar({ onMenuClick }: TopBarProps) {
+  const navigate = useNavigate()
+  const isMobile = useIsMobile()
+
+  return (
+    <header className="fixed top-0 left-0 right-0 z-50 bg-white shadow py-3 px-4 flex items-center justify-between">
+      <div className="flex items-center space-x-2">
+        {isMobile && (
+          <button onClick={onMenuClick} className="mr-2 md:hidden">
+            <Menu className="h-6 w-6" />
+          </button>
+        )}
+        <h1 className="font-bold text-lg">MAM’s FACTURE</h1>
+      </div>
+      <button onClick={() => navigate('/')} className="flex items-center space-x-1 text-sm">
+        <Home className="h-4 w-4" />
+        <span>Accueil</span>
+      </button>
+    </header>
+  )
+}

--- a/frontend/src/components/cards/StatsCarousel.tsx
+++ b/frontend/src/components/cards/StatsCarousel.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState, useMemo } from 'react';
 import { Link } from 'react-router-dom';
+import { motion } from 'framer-motion';
 import {
   Carousel,
   CarouselContent,
@@ -76,31 +77,52 @@ export function StatsCarousel() {
       <Carousel setApi={setApi} className="w-full">
         <CarouselContent>
           <CarouselItem>
-            <Link to="/factures?status=unpaid" className="block">
-              <InvoicePieChart />
-            </Link>
+            <motion.div
+              initial={{ opacity: 0, y: 10 }}
+              animate={{ opacity: index === 0 ? 1 : 0, y: index === 0 ? 0 : 10 }}
+              exit={{ opacity: 0, y: -10 }}
+              transition={{ duration: 0.3 }}
+            >
+              <Link to="/factures?status=unpaid" className="block">
+                <InvoicePieChart />
+              </Link>
+            </motion.div>
           </CarouselItem>
           <CarouselItem>
-            <Card>
-              <CardHeader>
-                <CardTitle>Paiements en attente</CardTitle>
-              </CardHeader>
-              <CardContent className="text-center">
-                <p className="text-3xl font-bold">
-                  {euro.format(unpaidTotal)}
-                </p>
-              </CardContent>
-            </Card>
+            <motion.div
+              initial={{ opacity: 0, y: 10 }}
+              animate={{ opacity: index === 1 ? 1 : 0, y: index === 1 ? 0 : 10 }}
+              exit={{ opacity: 0, y: -10 }}
+              transition={{ duration: 0.3 }}
+            >
+              <Card>
+                <CardHeader>
+                  <CardTitle>Paiements en attente</CardTitle>
+                </CardHeader>
+                <CardContent className="text-center">
+                  <p className="text-3xl font-bold">
+                    {euro.format(unpaidTotal)}
+                  </p>
+                </CardContent>
+              </Card>
+            </motion.div>
           </CarouselItem>
           <CarouselItem>
-            <Card>
-              <CardHeader>
-                <CardTitle>Factures générées ce mois-ci</CardTitle>
-              </CardHeader>
-              <CardContent className="text-center">
-                <p className="text-3xl font-bold">{invoicesThisMonth}</p>
-              </CardContent>
-            </Card>
+            <motion.div
+              initial={{ opacity: 0, y: 10 }}
+              animate={{ opacity: index === 2 ? 1 : 0, y: index === 2 ? 0 : 10 }}
+              exit={{ opacity: 0, y: -10 }}
+              transition={{ duration: 0.3 }}
+            >
+              <Card>
+                <CardHeader>
+                  <CardTitle>Factures générées ce mois-ci</CardTitle>
+                </CardHeader>
+                <CardContent className="text-center">
+                  <p className="text-3xl font-bold">{invoicesThisMonth}</p>
+                </CardContent>
+              </Card>
+            </motion.div>
           </CarouselItem>
         </CarouselContent>
         <CarouselPrevious className="-left-4" />


### PR DESCRIPTION
## Summary
- create `TopBar` with app name and home button
- make sidebar controllable and show overlay when open
- include `TopBar` in layout and manage sidebar state in `App`
- animate `StatsCarousel` slides with framer-motion

## Testing
- `cd backend && pnpm install && pnpm test`
- `cd frontend && pnpm install && pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6858ad3eacb0832f99fa572e753cfa31