### PR TITLE
Add legal info fields to clients

### DIFF
--- a/backend/database/sqlite.js
+++ b/backend/database/sqlite.js
@@ -31,8 +31,12 @@ class SQLiteDatabase {
       email TEXT,
       adresse_facturation TEXT,
       adresse_livraison TEXT,
+      intitule TEXT,
+      siren TEXT,
       siret TEXT,
+      legal_form TEXT,
       tva TEXT,
+      rcs_number TEXT,
       logo TEXT,
       nombre_de_factures INTEGER DEFAULT 0,
       factures_payees INTEGER DEFAULT 0,
@@ -71,6 +75,10 @@ class SQLiteDatabase {
     if (!cols.includes('factures_impayees')) this.db.run('ALTER TABLE clients ADD COLUMN factures_impayees INTEGER DEFAULT 0');
     if (!cols.includes('total_facture')) this.db.run('ALTER TABLE clients ADD COLUMN total_facture REAL DEFAULT 0');
     if (!cols.includes('total_paye')) this.db.run('ALTER TABLE clients ADD COLUMN total_paye REAL DEFAULT 0');
+    if (!cols.includes('intitule')) this.db.run("ALTER TABLE clients ADD COLUMN intitule TEXT");
+    if (!cols.includes('siren')) this.db.run("ALTER TABLE clients ADD COLUMN siren TEXT");
+    if (!cols.includes('legal_form')) this.db.run("ALTER TABLE clients ADD COLUMN legal_form TEXT");
+    if (!cols.includes('rcs_number')) this.db.run("ALTER TABLE clients ADD COLUMN rcs_number TEXT");
     this.save();
   }
 
@@ -102,7 +110,7 @@ class SQLiteDatabase {
   }
 
   createClient(data) {
-    const stmt = this.db.prepare('INSERT INTO clients (nom_client, prenom_client, nom_entreprise, telephone, email, adresse_facturation, adresse_livraison, siret, tva, logo) VALUES (?,?,?,?,?,?,?,?,?,?)');
+    const stmt = this.db.prepare('INSERT INTO clients (nom_client, prenom_client, nom_entreprise, telephone, email, adresse_facturation, adresse_livraison, intitule, siren, siret, legal_form, tva, rcs_number, logo) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)');
     stmt.run([
       data.nom_client,
       data.prenom_client || '',
@@ -111,8 +119,12 @@ class SQLiteDatabase {
       data.email || '',
       data.adresse_facturation || '',
       data.adresse_livraison || '',
+      data.intitule || '',
+      data.siren || '',
       data.siret || '',
+      data.legal_form || '',
       data.tva || '',
+      data.rcs_number || '',
       data.logo || ''
     ]);
     stmt.free();
@@ -122,7 +134,7 @@ class SQLiteDatabase {
   }
 
   updateClient(id, data) {
-    const stmt = this.db.prepare('UPDATE clients SET nom_client=?, prenom_client=?, nom_entreprise=?, telephone=?, email=?, adresse_facturation=?, adresse_livraison=?, siret=?, tva=?, logo=?, updated_at=CURRENT_TIMESTAMP WHERE id=?');
+    const stmt = this.db.prepare('UPDATE clients SET nom_client=?, prenom_client=?, nom_entreprise=?, telephone=?, email=?, adresse_facturation=?, adresse_livraison=?, intitule=?, siren=?, siret=?, legal_form=?, tva=?, rcs_number=?, logo=?, updated_at=CURRENT_TIMESTAMP WHERE id=?');
     stmt.run([
       data.nom_client,
       data.prenom_client || '',
@@ -131,8 +143,12 @@ class SQLiteDatabase {
       data.email || '',
       data.adresse_facturation || '',
       data.adresse_livraison || '',
+      data.intitule || '',
+      data.siren || '',
       data.siret || '',
+      data.legal_form || '',
       data.tva || '',
+      data.rcs_number || '',
       data.logo || '',
       id
     ]);

--- a/backend/server.js
+++ b/backend/server.js
@@ -145,8 +145,12 @@ app.post('/api/clients', (req, res) => {
       email = '',
       adresse_facturation = '',
       adresse_livraison = '',
+      intitule = '',
+      siren = '',
       siret = '',
+      legal_form = '',
       tva = '',
+      rcs_number = '',
       logo = ''
     } = req.body;
     if (!nom_client) {
@@ -160,8 +164,12 @@ app.post('/api/clients', (req, res) => {
       email: email.trim(),
       adresse_facturation: adresse_facturation.trim(),
       adresse_livraison: adresse_livraison.trim(),
+      intitule: intitule.trim(),
+      siren: siren.trim(),
       siret: siret.trim(),
+      legal_form: legal_form.trim(),
       tva: tva.trim(),
+      rcs_number: rcs_number.trim(),
       logo: logo.trim()
     });
     db.synchroniserFacturesParClient();
@@ -198,8 +206,12 @@ app.put('/api/clients/:id', (req, res) => {
       email = '',
       adresse_facturation = '',
       adresse_livraison = '',
+      intitule = '',
+      siren = '',
       siret = '',
+      legal_form = '',
       tva = '',
+      rcs_number = '',
       logo = ''
     } = req.body;
     if (!nom_client) {
@@ -213,8 +225,12 @@ app.put('/api/clients/:id', (req, res) => {
       email: email.trim(),
       adresse_facturation: adresse_facturation.trim(),
       adresse_livraison: adresse_livraison.trim(),
+      intitule: intitule.trim(),
+      siren: siren.trim(),
       siret: siret.trim(),
+      legal_form: legal_form.trim(),
       tva: tva.trim(),
+      rcs_number: rcs_number.trim(),
       logo: logo.trim()
     });
     if (!success) return res.status(404).json({ error: 'Client non trouvé' });

--- a/frontend/src/pages/Clients.tsx
+++ b/frontend/src/pages/Clients.tsx
@@ -18,6 +18,13 @@ interface Client {
   nom_entreprise?: string
   telephone?: string
   adresse?: string
+  email?: string
+  intitule?: string
+  siren?: string
+  siret?: string
+  legal_form?: string
+  tva?: string
+  rcs_number?: string
   factures: number[]
 }
 
@@ -28,12 +35,26 @@ export default function Clients() {
   const [entreprise, setEntreprise] = useState('')
   const [telephone, setTelephone] = useState('')
   const [adresse, setAdresse] = useState('')
+  const [email, setEmail] = useState('')
+  const [intitule, setIntitule] = useState('')
+  const [siren, setSiren] = useState('')
+  const [siret, setSiret] = useState('')
+  const [legalForm, setLegalForm] = useState('')
+  const [tva, setTva] = useState('')
+  const [rcsNumber, setRcsNumber] = useState('')
   const [showForm, setShowForm] = useState(false)
   const [editingId, setEditingId] = useState<number | null>(null)
   const [editNom, setEditNom] = useState('')
   const [editEntreprise, setEditEntreprise] = useState('')
   const [editTelephone, setEditTelephone] = useState('')
   const [editAdresse, setEditAdresse] = useState('')
+  const [editEmail, setEditEmail] = useState('')
+  const [editIntitule, setEditIntitule] = useState('')
+  const [editSiren, setEditSiren] = useState('')
+  const [editSiret, setEditSiret] = useState('')
+  const [editLegalForm, setEditLegalForm] = useState('')
+  const [editTva, setEditTva] = useState('')
+  const [editRcsNumber, setEditRcsNumber] = useState('')
 
   const chargerClients = async () => {
     const res = await fetch(`${API_URL}/clients`)
@@ -57,7 +78,14 @@ export default function Clients() {
         nom_client: nom,
         nom_entreprise: entreprise,
         telephone,
-        adresse
+        adresse,
+        email,
+        intitule,
+        siren,
+        siret,
+        legal_form: legalForm,
+        tva,
+        rcs_number: rcsNumber
       })
     })
     if (res.ok) {
@@ -65,6 +93,13 @@ export default function Clients() {
       setEntreprise('')
       setTelephone('')
       setAdresse('')
+      setEmail('')
+      setIntitule('')
+      setSiren('')
+      setSiret('')
+      setLegalForm('')
+      setTva('')
+      setRcsNumber('')
       setShowForm(false)
       chargerClients()
     } else {
@@ -84,7 +119,14 @@ export default function Clients() {
         nom_client: editNom,
         nom_entreprise: editEntreprise,
         telephone: editTelephone,
-        adresse: editAdresse
+        adresse: editAdresse,
+        email: editEmail,
+        intitule: editIntitule,
+        siren: editSiren,
+        siret: editSiret,
+        legal_form: editLegalForm,
+        tva: editTva,
+        rcs_number: editRcsNumber
       })
     })
     if (res.ok) {
@@ -93,6 +135,13 @@ export default function Clients() {
       setEditEntreprise('')
       setEditTelephone('')
       setEditAdresse('')
+      setEditEmail('')
+      setEditIntitule('')
+      setEditSiren('')
+      setEditSiret('')
+      setEditLegalForm('')
+      setEditTva('')
+      setEditRcsNumber('')
       chargerClients()
     }
   }
@@ -118,32 +167,69 @@ export default function Clients() {
               <span className="font-semibold">Nouveau client</span>
             </button>
           ) : (
-            <form onSubmit={creerClient} className="w-full space-y-2">
-              <div>
-                <Label>Nom *</Label>
-                <Input value={nom} onChange={(e) => setNom(e.target.value)} />
+            <form onSubmit={creerClient} className="w-full space-y-4">
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+                <div>
+                  <Label>Nom *</Label>
+                  <Input value={nom} onChange={(e) => setNom(e.target.value)} />
+                </div>
+                <div>
+                  <Label>Entreprise</Label>
+                  <Input
+                    value={entreprise}
+                    onChange={(e) => setEntreprise(e.target.value)}
+                  />
+                </div>
+                <div>
+                  <Label>Téléphone</Label>
+                  <Input
+                    value={telephone}
+                    onChange={(e) => setTelephone(e.target.value)}
+                  />
+                </div>
+                <div>
+                  <Label>Adresse</Label>
+                  <Input
+                    value={adresse}
+                    onChange={(e) => setAdresse(e.target.value)}
+                  />
+                </div>
               </div>
-              <div>
-                <Label>Entreprise</Label>
-                <Input
-                  value={entreprise}
-                  onChange={(e) => setEntreprise(e.target.value)}
-                />
-              </div>
-              <div>
-                <Label>Téléphone</Label>
-                <Input
-                  value={telephone}
-                  onChange={(e) => setTelephone(e.target.value)}
-                />
-              </div>
-              <div>
-                <Label>Adresse</Label>
-                <Input
-                  value={adresse}
-                  onChange={(e) => setAdresse(e.target.value)}
-                />
-              </div>
+
+              <fieldset className="border border-gray-200 p-2 rounded-md">
+                <legend className="text-sm font-medium">Informations légales</legend>
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 mt-2">
+                  <div>
+                    <Label>Email</Label>
+                    <Input value={email} onChange={(e) => setEmail(e.target.value)} />
+                  </div>
+                  <div>
+                    <Label>Intitulé</Label>
+                    <Input value={intitule} onChange={(e) => setIntitule(e.target.value)} />
+                  </div>
+                  <div>
+                    <Label>SIREN</Label>
+                    <Input value={siren} onChange={(e) => setSiren(e.target.value)} />
+                  </div>
+                  <div>
+                    <Label>SIRET</Label>
+                    <Input value={siret} onChange={(e) => setSiret(e.target.value)} />
+                  </div>
+                  <div>
+                    <Label>Forme juridique</Label>
+                    <Input value={legalForm} onChange={(e) => setLegalForm(e.target.value)} />
+                  </div>
+                  <div>
+                    <Label>N° TVA</Label>
+                    <Input value={tva} onChange={(e) => setTva(e.target.value)} />
+                  </div>
+                  <div className="sm:col-span-2">
+                    <Label>N° RCS</Label>
+                    <Input value={rcsNumber} onChange={(e) => setRcsNumber(e.target.value)} />
+                  </div>
+                </div>
+              </fieldset>
+
               <div className="flex gap-2">
                 <Button type="submit">Ajouter</Button>
                 <Button
@@ -154,6 +240,13 @@ export default function Clients() {
                     setEntreprise('')
                     setTelephone('')
                     setAdresse('')
+                    setEmail('')
+                    setIntitule('')
+                    setSiren('')
+                    setSiret('')
+                    setLegalForm('')
+                    setTva('')
+                    setRcsNumber('')
                     setShowForm(false)
                   }}
                 >
@@ -170,23 +263,60 @@ export default function Clients() {
                 <CardTitle>Modifier {c.nom_client}</CardTitle>
               </CardHeader>
               <CardContent>
-                <form onSubmit={majClient} className="space-y-2">
-                  <div>
-                    <Label>Nom *</Label>
-                    <Input value={editNom} onChange={(e) => setEditNom(e.target.value)} />
+                <form onSubmit={majClient} className="space-y-4">
+                  <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+                    <div>
+                      <Label>Nom *</Label>
+                      <Input value={editNom} onChange={(e) => setEditNom(e.target.value)} />
+                    </div>
+                    <div>
+                      <Label>Entreprise</Label>
+                      <Input value={editEntreprise} onChange={(e) => setEditEntreprise(e.target.value)} />
+                    </div>
+                    <div>
+                      <Label>Téléphone</Label>
+                      <Input value={editTelephone} onChange={(e) => setEditTelephone(e.target.value)} />
+                    </div>
+                    <div>
+                      <Label>Adresse</Label>
+                      <Input value={editAdresse} onChange={(e) => setEditAdresse(e.target.value)} />
+                    </div>
                   </div>
-                  <div>
-                    <Label>Entreprise</Label>
-                    <Input value={editEntreprise} onChange={(e) => setEditEntreprise(e.target.value)} />
-                  </div>
-                  <div>
-                    <Label>Téléphone</Label>
-                    <Input value={editTelephone} onChange={(e) => setEditTelephone(e.target.value)} />
-                  </div>
-                  <div>
-                    <Label>Adresse</Label>
-                    <Input value={editAdresse} onChange={(e) => setEditAdresse(e.target.value)} />
-                  </div>
+
+                  <fieldset className="border border-gray-200 p-2 rounded-md">
+                    <legend className="text-sm font-medium">Informations légales</legend>
+                    <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 mt-2">
+                      <div>
+                        <Label>Email</Label>
+                        <Input value={editEmail} onChange={(e) => setEditEmail(e.target.value)} />
+                      </div>
+                      <div>
+                        <Label>Intitulé</Label>
+                        <Input value={editIntitule} onChange={(e) => setEditIntitule(e.target.value)} />
+                      </div>
+                      <div>
+                        <Label>SIREN</Label>
+                        <Input value={editSiren} onChange={(e) => setEditSiren(e.target.value)} />
+                      </div>
+                      <div>
+                        <Label>SIRET</Label>
+                        <Input value={editSiret} onChange={(e) => setEditSiret(e.target.value)} />
+                      </div>
+                      <div>
+                        <Label>Forme juridique</Label>
+                        <Input value={editLegalForm} onChange={(e) => setEditLegalForm(e.target.value)} />
+                      </div>
+                      <div>
+                        <Label>N° TVA</Label>
+                        <Input value={editTva} onChange={(e) => setEditTva(e.target.value)} />
+                      </div>
+                      <div className="sm:col-span-2">
+                        <Label>N° RCS</Label>
+                        <Input value={editRcsNumber} onChange={(e) => setEditRcsNumber(e.target.value)} />
+                      </div>
+                    </div>
+                  </fieldset>
+
                   <div className="flex gap-2">
                     <Button type="submit"><Save className="h-4 w-4 mr-1" /> Sauvegarder</Button>
                     <Button type="button" variant="outline" onClick={() => setEditingId(null)}>
@@ -208,6 +338,13 @@ export default function Clients() {
                       setEditEntreprise(c.nom_entreprise || '')
                       setEditTelephone(c.telephone || '')
                       setEditAdresse(c.adresse || '')
+                      setEditEmail(c.email || '')
+                      setEditIntitule(c.intitule || '')
+                      setEditSiren(c.siren || '')
+                      setEditSiret(c.siret || '')
+                      setEditLegalForm(c.legal_form || '')
+                      setEditTva(c.tva || '')
+                      setEditRcsNumber(c.rcs_number || '')
                     }}
                     className="p-1 text-gray-600 hover:text-blue-600"
                   >
@@ -219,6 +356,7 @@ export default function Clients() {
                 {c.nom_entreprise && <div>{c.nom_entreprise}</div>}
                 {c.telephone && <div>{c.telephone}</div>}
                 {c.adresse && <div>{c.adresse}</div>}
+                {c.email && <div>{c.email}</div>}
                 <div className="text-xs text-zinc-500">
                   {(c.factures || []).length} facture(s)
                 </div>

--- a/frontend/src/pages/CreerFacture.tsx
+++ b/frontend/src/pages/CreerFacture.tsx
@@ -34,7 +34,19 @@ export default function CreerFacture() {
   const [legalForm, setLegalForm] = useState('');
   const [vatNumber, setVatNumber] = useState('');
   const [rcsNumber, setRcsNumber] = useState('');
-  const [clients, setClients] = useState<Array<{id:number; nom_client:string; nom_entreprise?:string; telephone?:string; adresse?:string}>>([])
+  const [clients, setClients] = useState<Array<{
+    id: number
+    nom_client: string
+    nom_entreprise?: string
+    telephone?: string
+    adresse?: string
+    intitule?: string
+    siren?: string
+    siret?: string
+    legal_form?: string
+    tva?: string
+    rcs_number?: string
+  }>>([])
   const [clientId, setClientId] = useState<number | ''>('')
   const [lignes, setLignes] = useState<LigneFacture[]>([
     { description: '', quantite: 1, prix_unitaire: 0 }
@@ -67,6 +79,12 @@ export default function CreerFacture() {
       setNomEntreprise(client.nom_entreprise || '')
       setTelephone(client.telephone || '')
       setAdresse(client.adresse || '')
+      setSiren(client.siren || '')
+      setSiret(client.siret || '')
+      setLegalForm(client.legal_form || '')
+      setVatNumber(client.tva || '')
+      setRcsNumber(client.rcs_number || '')
+      setTitle(client.intitule || '')
     }
   }
 

--- a/frontend/src/pages/ModifierFacture.tsx
+++ b/frontend/src/pages/ModifierFacture.tsx
@@ -59,7 +59,19 @@ export default function ModifierFacture() {
   const [legalForm, setLegalForm] = useState('');
   const [vatNumber, setVatNumber] = useState('');
   const [rcsNumber, setRcsNumber] = useState('');
-  const [clients, setClients] = useState<Array<{id:number; nom_client:string; nom_entreprise?:string; telephone?:string; adresse?:string}>>([])
+  const [clients, setClients] = useState<Array<{
+    id: number
+    nom_client: string
+    nom_entreprise?: string
+    telephone?: string
+    adresse?: string
+    intitule?: string
+    siren?: string
+    siret?: string
+    legal_form?: string
+    tva?: string
+    rcs_number?: string
+  }>>([])
   const [clientId, setClientId] = useState<number | ''>('')
   const [lignes, setLignes] = useState<LigneFacture[]>([
     { description: '', quantite: 1, prix_unitaire: 0 }
@@ -94,6 +106,12 @@ export default function ModifierFacture() {
       setNomEntreprise(client.nom_entreprise || '')
       setTelephone(client.telephone || '')
       setAdresse(client.adresse || '')
+      setSiren(client.siren || '')
+      setSiret(client.siret || '')
+      setLegalForm(client.legal_form || '')
+      setVatNumber(client.tva || '')
+      setRcsNumber(client.rcs_number || '')
+      setTitle(client.intitule || '')
     }
   }
 

--- a/frontend/src/pages/profiles/ClientProfile.tsx
+++ b/frontend/src/pages/profiles/ClientProfile.tsx
@@ -10,6 +10,13 @@ interface Client {
   nom_entreprise?: string
   telephone?: string
   adresse?: string
+  email?: string
+  intitule?: string
+  siren?: string
+  siret?: string
+  legal_form?: string
+  tva?: string
+  rcs_number?: string
   factures: number[]
 }
 
@@ -61,6 +68,13 @@ export default function ClientProfile() {
           {client.nom_entreprise && <div>Entreprise : {client.nom_entreprise}</div>}
           {client.telephone && <div>Téléphone : {client.telephone}</div>}
           {client.adresse && <div>Adresse : {client.adresse}</div>}
+          {client.email && <div>Email : {client.email}</div>}
+          {client.intitule && <div>Intitulé : {client.intitule}</div>}
+          {client.siren && <div>SIREN : {client.siren}</div>}
+          {client.siret && <div>SIRET : {client.siret}</div>}
+          {client.legal_form && <div>Forme juridique : {client.legal_form}</div>}
+          {client.tva && <div>N° TVA : {client.tva}</div>}
+          {client.rcs_number && <div>RCS : {client.rcs_number}</div>}
           <div>{(client.factures || []).length} facture(s)</div>
         </CardContent>
       </Card>


### PR DESCRIPTION
## Summary
- extend SQLite client table and server endpoints for legal info
- capture new details in client creation and edit forms
- prefill invoice creation and editing from selected client
- show all client legal info on profile page

## Testing
- `pnpm install` && `pnpm test` in `backend`
- `pnpm install` && `pnpm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_6858b0cb28ac832fa9fe74237c922c8c