### PR TITLE
Fix facture status update via PUT

### DIFF
--- a/backend/tests/status.test.js
+++ b/backend/tests/status.test.js
@@ -5,7 +5,7 @@ beforeAll(async () => {
   app = await require('../server');
 });
 
-describe('PATCH /api/factures/:id/status', () => {
+describe('PUT /api/factures/:id', () => {
   test('updates invoice status', async () => {
     const createRes = await request(app)
       .post('/api/factures')
@@ -18,10 +18,10 @@ describe('PATCH /api/factures/:id/status', () => {
     const id = createRes.body.id;
 
     const patchRes = await request(app)
-      .patch(`/api/factures/${id}/status`)
-      .send({ status: 'paid' });
+      .put(`/api/factures/${id}`)
+      .send({ statut: 'payée' });
     expect(patchRes.status).toBe(200);
-    expect(patchRes.body.message).toBe('Statut mis à jour');
+    expect(patchRes.body.status).toBe('paid');
 
     const getRes = await request(app).get(`/api/factures/${id}`);
     expect(getRes.status).toBe(200);

--- a/frontend/src/pages/ListeFactures.test.tsx
+++ b/frontend/src/pages/ListeFactures.test.tsx
@@ -23,7 +23,7 @@ const facturesResponse = {
 global.fetch = jest
   .fn()
   .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(facturesResponse) })
-  .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ message: 'Statut mis à jour' }) });
+  .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ id: 1, status: 'paid' }) });
 
 test('marque une facture comme payée', async () => {
   render(
@@ -38,8 +38,8 @@ test('marque une facture comme payée', async () => {
 
   await waitFor(() =>
     expect(fetch as any).toHaveBeenCalledWith(
-      expect.stringContaining('/status'),
-      expect.objectContaining({ method: 'PATCH' })
+      expect.stringContaining('/factures/1'),
+      expect.objectContaining({ method: 'PUT' })
     )
   );
 });

--- a/frontend/src/pages/ListeFactures.tsx
+++ b/frontend/src/pages/ListeFactures.tsx
@@ -178,17 +178,18 @@ export default function ListeFactures() {
 
   const marquerPayee = async (id: number) => {
     try {
-      const response = await fetch(`${API_URL}/factures/${id}/status`, {
-        method: "PATCH",
+      const response = await fetch(`${API_URL}/factures/${id}`, {
+        method: "PUT",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ status: "paid" })
+        body: JSON.stringify({ statut: "payée" })
       });
       if (!response.ok) {
         throw new Error("Erreur lors du changement de statut");
       }
+      const updatedFacture = await response.json();
       setFactures(prev => {
         const updated = prev.map(f =>
-          f.id === id ? { ...f, status: 'paid' as const } : f
+          f.id === id ? { ...f, status: updatedFacture.status } : f
         );
         return statusFilter === "unpaid"
           ? updated.filter(f => f.id !== id)


### PR DESCRIPTION
## Summary
- allow partial updates in `PUT /api/factures/:id`
- convert `statut` to `status` and validate values
- update frontend to call this PUT endpoint when marking invoices as paid
- adjust related backend and frontend tests

## Testing
- `cd backend && pnpm install && pnpm test`
- `cd frontend && pnpm install && pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6858b58423b8832fa6d69b2686f3036a