### PR TITLE
Affiche toutes les infos du client

### DIFF
--- a/backend/tests/clients.test.js
+++ b/backend/tests/clients.test.js
@@ -52,4 +52,36 @@ describe('Client creation and listing', () => {
     expect(created).toBeTruthy();
     expect(created.nom_client).toBe('Nouveau Client');
   });
+
+  test('GET /api/clients/:id returns all fields', async () => {
+    const payload = {
+      nom_client: 'Full Fields',
+      telephone: '000',
+      email: 'full@example.com',
+      siren: '123456789',
+      siret: '12345678900011',
+      legal_form: 'SARL',
+      tva: 'FR123456789',
+      rcs_number: 'RCS 123',
+      logo: '/img.png'
+    };
+    const res = await request(app).post('/api/clients').send(payload);
+    expect(res.status).toBe(201);
+    const id = res.body.id;
+
+    const getRes = await request(app).get(`/api/clients/${id}`);
+    expect(getRes.status).toBe(200);
+    expect(getRes.body).toEqual(
+      expect.objectContaining({
+        id,
+        email: payload.email,
+        siren: payload.siren,
+        siret: payload.siret,
+        legal_form: payload.legal_form,
+        tva: payload.tva,
+        rcs_number: payload.rcs_number,
+        logo: payload.logo
+      })
+    );
+  });
 });

--- a/frontend/src/pages/profiles/ClientProfile.tsx
+++ b/frontend/src/pages/profiles/ClientProfile.tsx
@@ -7,16 +7,19 @@ import { ArrowLeft } from 'lucide-react'
 interface Client {
   id: number
   nom_client: string
+  prenom_client?: string
   nom_entreprise?: string
   telephone?: string
-  adresse?: string
   email?: string
+  adresse_facturation?: string
+  adresse_livraison?: string
   intitule?: string
   siren?: string
   siret?: string
   legal_form?: string
   tva?: string
   rcs_number?: string
+  logo?: string
   factures: number[]
 }
 
@@ -64,17 +67,30 @@ export default function ClientProfile() {
         <CardHeader>
           <CardTitle>{client.nom_client}</CardTitle>
         </CardHeader>
-        <CardContent className="space-y-2 text-sm">
+        <CardContent className="space-y-4 text-sm">
+          {client.logo ? (
+            <img src={client.logo} alt="logo" className="h-20 object-contain" />
+          ) : (
+            <div className="h-20 w-20 bg-zinc-100 flex items-center justify-center rounded-md text-zinc-400">
+              Aucune image
+            </div>
+          )}
           {client.nom_entreprise && <div>Entreprise : {client.nom_entreprise}</div>}
           {client.telephone && <div>Téléphone : {client.telephone}</div>}
-          {client.adresse && <div>Adresse : {client.adresse}</div>}
-          {client.email && <div>Email : {client.email}</div>}
+          {client.adresse_facturation && <div>Adresse facturation : {client.adresse_facturation}</div>}
+          {client.adresse_livraison && <div>Adresse livraison : {client.adresse_livraison}</div>}
           {client.intitule && <div>Intitulé : {client.intitule}</div>}
-          {client.siren && <div>SIREN : {client.siren}</div>}
-          {client.siret && <div>SIRET : {client.siret}</div>}
-          {client.legal_form && <div>Forme juridique : {client.legal_form}</div>}
-          {client.tva && <div>N° TVA : {client.tva}</div>}
-          {client.rcs_number && <div>RCS : {client.rcs_number}</div>}
+
+          <fieldset className="border border-gray-200 rounded-md p-2 shadow-sm space-y-1">
+            <legend className="text-sm font-medium">Informations légales</legend>
+            <div>Email : {client.email || ''}</div>
+            <div>SIREN : {client.siren || ''}</div>
+            <div>SIRET : {client.siret || ''}</div>
+            <div>RCS : {client.rcs_number || ''}</div>
+            <div>Forme juridique : {client.legal_form || ''}</div>
+            <div>N° TVA : {client.tva || ''}</div>
+          </fieldset>
+
           <div>{(client.factures || []).length} facture(s)</div>
         </CardContent>
       </Card>


### PR DESCRIPTION
## Summary
- add missing fields to client profile page and style a "Informations légales" section
- test backend endpoint returns all client fields

## Testing
- `cd backend && pnpm test`
- `cd frontend && pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6858b609cb94832f86deb275e4c5bb6e