### PR TITLE
Fix paid invoices filter

### DIFF
--- a/backend/database/sqlite.js
+++ b/backend/database/sqlite.js
@@ -159,7 +159,7 @@ class SQLiteDatabase {
   }
 
   // Factures
-  getFactures() {
+  getFactures(filters = {}) {
     const stmt = this.db.prepare('SELECT * FROM factures ORDER BY date_facture DESC');
     const result = [];
     while (stmt.step()) {
@@ -168,6 +168,10 @@ class SQLiteDatabase {
       result.push(row);
     }
     stmt.free();
+
+    if (filters.status) {
+      return result.filter(f => f.status === filters.status);
+    }
     return result;
   }
 

--- a/backend/server.js
+++ b/backend/server.js
@@ -253,6 +253,7 @@ app.get('/api/factures', (req, res) => {
       dateDebut = '',
       dateFin = '',
       status = '',
+      statut = '',
       sortBy = 'date',
       order = 'desc'
     } = req.query;
@@ -263,7 +264,12 @@ app.get('/api/factures', (req, res) => {
     const offset = (pageNum - 1) * limitNum;
 
     const filters = { search, dateDebut, dateFin };
-    if (status) filters.status = status;
+    let statusFilter = status;
+    if (!statusFilter && statut) {
+      if (statut === 'payee') statusFilter = 'paid';
+      else if (statut === 'impayee') statusFilter = 'unpaid';
+    }
+    if (statusFilter) filters.status = statusFilter;
     const allFactures = db.getFactures(filters);
 
     // Tri
@@ -300,6 +306,10 @@ app.get('/api/factures', (req, res) => {
       date_facture_fr: formatDateFR(row.date_facture),
       montant_total_fr: formatEuro(row.montant_total)
     }));
+
+    if (statut) {
+      console.log('Factures filtrées par statut', statut, facturesFormatees);
+    }
 
     res.json({
       factures: facturesFormatees,

--- a/backend/tests/filterStatut.test.js
+++ b/backend/tests/filterStatut.test.js
@@ -1,0 +1,15 @@
+const request = require('supertest');
+let app;
+
+beforeAll(async () => {
+  app = await require('../server');
+});
+
+describe('GET /api/factures?statut=payee', () => {
+  test('returns only paid invoices', async () => {
+    const res = await request(app).get('/api/factures?statut=payee');
+    expect(res.status).toBe(200);
+    const statuses = res.body.factures.map(f => f.status);
+    expect(new Set(statuses)).toEqual(new Set(['paid']));
+  });
+});

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -33,11 +33,11 @@ export default function Sidebar({ open, setOpen }: SidebarProps) {
           <FileText className="h-5 w-5" />
           <span>Toutes les factures</span>
         </NavLink>
-        <NavLink to="/factures?status=unpaid" className="flex items-center space-x-2 hover:text-primary">
+        <NavLink to="/factures?statut=impayee" className="flex items-center space-x-2 hover:text-primary">
           <CircleAlert className="h-5 w-5" />
           <span>Factures non payées</span>
         </NavLink>
-        <NavLink to="/factures?status=paid" className="flex items-center space-x-2 hover:text-primary">
+        <NavLink to="/factures?statut=payee" className="flex items-center space-x-2 hover:text-primary">
           <CircleAlert className="h-5 w-5" />
           <span>Factures payées</span>
         </NavLink>

--- a/frontend/src/pages/ListeFactures.tsx
+++ b/frontend/src/pages/ListeFactures.tsx
@@ -67,16 +67,17 @@ export default function ListeFactures() {
   const chargerFactures = useCallback(async () => {
     try {
       setLoading(true);
-      const params = new URLSearchParams({
-        page: pagination.page.toString(),
-        limit: pagination.limit.toString(),
-        search: recherche,
-        dateDebut,
-        dateFin,
-        status: statusFilter,
-        sortBy: sortField,
-        order: sortOrder
-      });
+      const params = new URLSearchParams();
+      params.set('page', pagination.page.toString());
+      params.set('limit', pagination.limit.toString());
+      params.set('search', recherche);
+      params.set('dateDebut', dateDebut);
+      params.set('dateFin', dateFin);
+      if (statusFilter) {
+        params.set('statut', statusFilter === 'paid' ? 'payee' : 'impayee');
+      }
+      params.set('sortBy', sortField);
+      params.set('order', sortOrder);
 
       const response = await fetch(`${API_URL}/factures?${params}`);
       if (!response.ok) {
@@ -84,6 +85,7 @@ export default function ListeFactures() {
       }
 
       const data = await response.json();
+      console.log('Factures chargées', data.factures);
       setFactures(data.factures);
       setPagination(data.pagination);
     } catch (err) {
@@ -100,7 +102,12 @@ export default function ListeFactures() {
   useEffect(() => {
     const params = new URLSearchParams(location.search);
     const st = params.get('status');
-    if (st) setStatusFilter(st);
+    const statut = params.get('statut');
+    if (statut) {
+      setStatusFilter(statut === 'payee' ? 'paid' : 'unpaid');
+    } else if (st) {
+      setStatusFilter(st);
+    }
   }, [location.search]);
 
   const supprimerFacture = async (id: number, numeroFacture: string) => {


### PR DESCRIPTION
## Summary
- support `statut` query param in backend invoice list API
- filter by status in sqlite backend
- log filtered invoices when `statut` is used
- adapt sidebar links to use `statut`
- map `statut` to paid/unpaid in invoice list page
- send `statut` param when fetching invoices
- add test for `statut=payee` filter

## Testing
- `cd backend && pnpm install && pnpm test`
- `cd frontend && pnpm install && pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6858b6938e40832fb000040757817a91