### PR TITLE
Improve layout and mobile theme

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -58,7 +58,7 @@ function App() {
             <Sidebar open={sidebarOpen} setOpen={setSidebarOpen} />
             <div className="flex flex-col flex-1">
               <TopBar onMenuClick={() => setSidebarOpen(true)} />
-              <main className="flex-1 overflow-auto pt-16 px-4 py-6">
+              <main className="flex-1 overflow-auto pt-16 px-4 py-6 pl-0 md:pl-56">
                 <AnimatedRoutes />
               </main>
             </div>

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -24,7 +24,8 @@ export default function Sidebar({ open, setOpen }: SidebarProps) {
         </button>
       )}
       <div className="flex flex-col justify-between h-full">
-        <div className="space-y-2 mt-6">
+        <h1 className="text-center font-bold text-xl mb-6">MAM’s FACTURE</h1>
+        <div className="space-y-2">
         <NavLink to="/" className="flex items-center space-x-2 hover:text-primary">
           <Home className="h-5 w-5" />
           <span>Accueil</span>

--- a/frontend/src/components/TopBar.tsx
+++ b/frontend/src/components/TopBar.tsx
@@ -1,5 +1,5 @@
 import { Menu, Home } from 'lucide-react'
-import { useNavigate } from 'react-router-dom'
+import { useNavigate, useLocation } from 'react-router-dom'
 import { useIsMobile } from '../hooks/use-mobile'
 
 interface TopBarProps {
@@ -8,18 +8,27 @@ interface TopBarProps {
 
 export default function TopBar({ onMenuClick }: TopBarProps) {
   const navigate = useNavigate()
+  const location = useLocation()
   const isMobile = useIsMobile()
 
+  const titles: Record<string, string> = {
+    '/': 'Accueil',
+    '/factures': 'Toutes les factures',
+    '/factures/payees': 'Factures payées',
+    '/factures/non-payees': 'Factures non payées',
+    '/clients': 'Clients',
+  }
+
+  const title = titles[location.pathname] || 'MAM\u2019s FACTURE'
+
   return (
-    <header className="fixed top-0 left-0 right-0 z-50 bg-white shadow py-3 px-4 flex items-center justify-between">
-      <div className="flex items-center space-x-2">
-        {isMobile && (
-          <button onClick={onMenuClick} className="mr-2 md:hidden">
-            <Menu className="h-6 w-6" />
-          </button>
-        )}
-        <h1 className="font-bold text-lg">MAM’s FACTURE</h1>
-      </div>
+    <header className="fixed top-0 right-0 z-50 bg-white shadow py-3 px-4 flex items-center justify-between md:left-56">
+      {isMobile && (
+        <button onClick={onMenuClick} className="mr-2 md:hidden">
+          <Menu className="h-6 w-6" />
+        </button>
+      )}
+      <h1 className="absolute left-1/2 -translate-x-1/2 font-bold text-lg">{title}</h1>
       <button onClick={() => navigate('/')} className="flex items-center space-x-1 text-sm">
         <Home className="h-4 w-4" />
         <span>Accueil</span>

--- a/frontend/src/pages/ListeFactures.tsx
+++ b/frontend/src/pages/ListeFactures.tsx
@@ -273,7 +273,7 @@ export default function ListeFactures() {
                   type="date"
                   value={dateDebut}
                   onChange={(e) => setDateDebut(e.target.value)}
-                  className="pl-10 w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
+                  className="pl-10 w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 text-[#DD4A3C] md:text-current"
                 />
               </div>
             </div>
@@ -287,7 +287,7 @@ export default function ListeFactures() {
                 type="date"
                 value={dateFin}
                 onChange={(e) => setDateFin(e.target.value)}
-                className="pl-10 w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
+                className="pl-10 w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 text-[#DD4A3C] md:text-current"
               />
             </div>
           </div>


### PR DESCRIPTION
## Summary
- offset TopBar when sidebar is visible
- center page title dynamically in TopBar
- move app logo to Sidebar
- adjust main content padding
- fix mobile text color for date inputs

## Testing
- `cd backend && pnpm install && pnpm test`
- `cd frontend && pnpm install && pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6858b783eba4832f9dda6cbb0016d0a4