### PR TITLE
Improve HTML invoice download UX

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -15,6 +15,7 @@ import TopBar from './components/TopBar'
 import { useState, useEffect } from 'react'
 import { useIsMobile } from './hooks/use-mobile'
 import { ThemeProvider } from './context/ThemeContext'
+import { Toaster } from './components/ui/sonner'
 
 function AnimatedRoutes() {
   const location = useLocation()
@@ -54,6 +55,7 @@ function App() {
     <ErrorBoundary>
       <ThemeProvider>
         <Router>
+          <Toaster />
           <div className="flex h-screen overflow-hidden">
             <Sidebar open={sidebarOpen} setOpen={setSidebarOpen} />
             <div className="flex flex-col flex-1">

--- a/frontend/src/pages/DetailFacture.tsx
+++ b/frontend/src/pages/DetailFacture.tsx
@@ -3,6 +3,7 @@ import { useParams, useNavigate, Link } from 'react-router-dom';
 import { ArrowLeft, Edit, Download, Trash2, FileText, User, Calendar, Euro } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { API_URL } from '@/lib/api';
+import { toast } from '@/hooks/use-toast';
 import { computeTotals } from '@/lib/utils';
 import { format } from 'date-fns';
 import { fr } from 'date-fns/locale';
@@ -97,10 +98,29 @@ export default function DetailFacture() {
     }
   };
 
-  const telechargerFacture = (): void => {
+  const telechargerFacture = async (): Promise<void> => {
     if (!facture) return;
     const url = `${API_URL}/factures/${facture.id}/html`;
-    window.open(url, '_blank');
+    try {
+      const res = await fetch(url);
+      if (!res.ok) {
+        throw new Error('Erreur lors du téléchargement');
+      }
+      const blob = await res.blob();
+      const link = document.createElement('a');
+      link.href = window.URL.createObjectURL(blob);
+      link.download = `facture-${facture.numero_facture}.html`;
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+      toast({ description: 'Le fichier a été téléchargé avec succès' });
+    } catch (err) {
+      toast({
+        description:
+          err instanceof Error ? err.message : 'Erreur lors du téléchargement',
+        variant: 'destructive'
+      });
+    }
   };
 
   const euroFormatter = new Intl.NumberFormat('fr-FR', {

--- a/frontend/src/pages/ListeFactures.tsx
+++ b/frontend/src/pages/ListeFactures.tsx
@@ -21,6 +21,7 @@ import {
   DropdownMenuTrigger
 } from '@/components/ui/dropdown-menu';
 import { API_URL } from '@/lib/api';
+import { toast } from '@/hooks/use-toast';
 
 interface Facture {
   id: number;
@@ -129,14 +130,33 @@ export default function ListeFactures() {
     }
   };
 
-  const telechargerFacture = (
+  const telechargerFacture = async (
     id: number,
     numeroFacture: string,
-    dateFacture: string,
-    nomEntreprise?: string
-  ): void => {
+    _dateFacture: string,
+    _nomEntreprise?: string
+  ): Promise<void> => {
     const url = `${API_URL}/factures/${id}/html`;
-    window.open(url, '_blank');
+    try {
+      const res = await fetch(url);
+      if (!res.ok) {
+        throw new Error('Erreur lors du téléchargement');
+      }
+      const blob = await res.blob();
+      const link = document.createElement('a');
+      link.href = window.URL.createObjectURL(blob);
+      link.download = `facture-${numeroFacture}.html`;
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+      toast({ description: 'Le fichier a été téléchargé avec succès' });
+    } catch (err) {
+      toast({
+        description:
+          err instanceof Error ? err.message : 'Erreur lors du téléchargement',
+        variant: 'destructive'
+      });
+    }
   };
 
   const marquerPayee = async (id: number) => {


### PR DESCRIPTION
## Summary
- add toast library integration in app
- show toast after downloading invoice in list and detail pages
- enable in-app toasts with Toaster component

## Testing
- `cd backend && pnpm test`
- `cd frontend && pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6858ba79f30c832f8f2f4be02d83879c