### PR TITLE
Update macOS installer and launcher

### DIFF
--- a/install_macos.sh
+++ b/install_macos.sh
@@ -18,6 +18,9 @@ if ! command -v brew >/dev/null 2>&1; then
   exit 1
 fi
 
+echo "[installer] Mise à jour de Homebrew..."
+brew update >/dev/null
+
 if ! command -v node >/dev/null 2>&1; then
   echo "[installer] Installation de Node.js via Homebrew..."
   brew install node

--- a/launch_safari.sh
+++ b/launch_safari.sh
@@ -30,10 +30,13 @@ if ! command -v node >/dev/null 2>&1 \
   ./install_macos.sh --skip-build
 fi
 
+# S'assure que les dépendances sont à jour
 PM=pnpm
 if ! command -v pnpm >/dev/null 2>&1; then
   PM=npm
 fi
+(cd backend && "$PM" install > /dev/null)
+(cd frontend && "$PM" install > /dev/null)
 
 echo "[launcher] Démarrage du backend..."
 (cd backend && "$PM" start > ../backend.log 2>&1 &)


### PR DESCRIPTION
## Summary
- update macOS installer to refresh Homebrew before installing
- ensure launcher always installs dependencies before starting

## Testing
- `cd backend && pnpm install && pnpm test`
- `cd frontend && pnpm install && pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6858bc8e6998832fb4011ab4050d0115