### PR TITLE
Improve HTML export and docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,3 +16,18 @@ All tests must pass.
 
 ## PR message
 Include separate **Summary** and **Testing** sections in the pull request body describing what was changed and confirming the tests ran.
+
+## Project Overview
+This repository contains a simple billing application split into two parts:
+
+- **backend/** – Node.js + Express API using a SQLite database stored in
+  `backend/database/facturation.sqlite`.  Main entry point is `server.js`.
+  Business logic for HTML invoice generation lives in `services/` and tests in
+  `backend/tests`.
+- **frontend/** – React application built with Vite.  Components are under
+  `src/components` and pages in `src/pages`.  End-to-end tests use Playwright in
+  `frontend/tests/e2e`.
+
+Run `./install.sh` from the project root to install both parts at once.  Start
+the API with `pnpm start` inside `backend/` and the UI with `pnpm run dev` inside
+`frontend/`.

--- a/backend/server.js
+++ b/backend/server.js
@@ -681,8 +681,11 @@ app.get('/api/factures/:id/html', async (req, res) => { // Made async
         numero: mappedData.numero_facture,
         date: facture.date_facture, // Needs to be in 'YYYY-MM-DD' or a parsable format for `new Date()` in generateInvoiceHTML
 
+        // Each item from mapFactureToInvoiceData already exposes a `description`
+        // field, so map it directly. Using `service` here caused `undefined`
+        // values and broke invoice HTML generation.
         lignes: mappedData.lignes_facture.map(l => ({
-          description: l.service,
+          description: l.description,
           quantite: l.quantity,
           prix_unitaire: l.unitPriceHT,
         })),


### PR DESCRIPTION
## Summary
- fix invoice HTML export by mapping `description` correctly
- document repo structure in `AGENTS.md`

## Testing
- `pnpm test` in `backend`
- `pnpm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_6859d212ba9c832f8ca580d18bb8eacd