### PR TITLE
Fix module imports for compiled backend

### DIFF
--- a/backend/invoiceHTML.ts
+++ b/backend/invoiceHTML.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import Decimal from 'decimal.js';
 // eslint-disable-next-line @typescript-eslint/no-var-requires
-const { computeTotals } = require('./utils/computeTotals.ts');
+const { computeTotals } = require('./utils/computeTotals');
 import { format } from 'date-fns';
 import { fr } from 'date-fns/locale';
 const euroFormatter = new Intl.NumberFormat('fr-FR', {

--- a/backend/package.json
+++ b/backend/package.json
@@ -4,8 +4,9 @@
   "description": "Application de facturation - Backend API",
   "main": "server.js",
   "scripts": {
-    "start": "node server.js",
-    "dev": "nodemon server.js",
+    "build": "tsc",
+    "start": "pnpm run build && node dist/server.js",
+    "dev": "nodemon server.ts",
     "test": "NODE_ENV=test API_TOKEN=test-token jest",
     "export-html": "node scripts/export-html.js"
   },

--- a/backend/server.ts
+++ b/backend/server.ts
@@ -7,10 +7,10 @@ const fs = require('fs');
 const multer = require('multer');
 // Import mapFactureToInvoiceData from htmlService
 const { mapFactureToInvoiceData } = require('./services/htmlService');
-// Import generateInvoiceHTML from invoiceHTML.ts
-const { generateInvoiceHTML } = require('./invoiceHTML.ts');
+// Import generateInvoiceHTML from invoiceHTML
+const { generateInvoiceHTML } = require('./invoiceHTML');
 const SQLiteDatabase = require('./database/sqlite');
-const { computeTotals } = require('./utils/computeTotals.ts');
+const { computeTotals } = require('./utils/computeTotals');
 const { getRandomQuote } = require('./services/quoteService');
 const { readUserProfile, writeUserProfile, USER_PROFILE_PATH } = require('./services/userProfileService');
 

--- a/backend/services/htmlService.js
+++ b/backend/services/htmlService.js
@@ -1,8 +1,7 @@
-require('ts-node/register/transpile-only');
 const path = require('path');
 const fs = require('fs');
 // const ejs = require('ejs'); // Not used directly for HTML string building here
-const { computeTotals } = require('../utils/computeTotals.ts'); // This computeTotals expects TTC unit prices
+const { computeTotals } = require('../utils/computeTotals'); // This computeTotals expects TTC unit prices
 const { fr } = require('date-fns/locale');
 const { format } = require('date-fns');
 const Decimal = require('decimal.js'); // Import Decimal.js

--- a/backend/tests/computeTotals.test.js
+++ b/backend/tests/computeTotals.test.js
@@ -1,4 +1,4 @@
-const { computeTotals } = require('../utils/computeTotals.ts');
+const { computeTotals } = require('../utils/computeTotals');
 
 describe('computeTotals', () => {
   test('calculates totals correctly with default VAT', () => {


### PR DESCRIPTION
## Summary
- drop `ts-node/register` and use compiled JS modules
- update imports in `server.ts`, `htmlService.js`, and `invoiceHTML.ts`
- run `tsc` before starting the backend
- adjust unit tests for new import paths

## Testing
- `cd backend && pnpm install && pnpm test`
- `cd frontend && pnpm install && pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6859e8d6868c832fbcbf2c601f3dbdd9