### PR TITLE
Corriger l'erreur de syntaxe dans backend/package.json

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -4,11 +4,9 @@
   "description": "Application de facturation - Backend API",
   "main": "dist/server.js",
   "scripts": {
-"scripts": {
-  "build": "tsc",
-  "start": "pnpm run build && node dist/server.js",
-  "dev": "nodemon --exec ts-node server.ts"
-}
+    "build": "tsc",
+    "start": "pnpm run build && node dist/server.js",
+    "dev": "nodemon --exec ts-node server.ts",
     "test": "NODE_ENV=test API_TOKEN=test-token jest",
     "export-html": "node scripts/export-html.js"
   },


### PR DESCRIPTION
Suppression d'une section 'scripts' imbriquée incorrectement qui empêchait l'installation des dépendances backend.