### PR TITLE
Increase timeout to 5 minutes

### DIFF
--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -1,6 +1,7 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
+  testTimeout: 300000,
   transform: {
     '^.+\\.tsx?$': [
       'ts-jest',

--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -1,6 +1,7 @@
 export default {
   preset: 'ts-jest/presets/default-esm',
   testEnvironment: 'jsdom',
+  testTimeout: 300000,
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/src/$1',
   },

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -17,6 +17,7 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   /* Retry on CI only */
   retries: process.env.CI ? 2 : 0,
+  timeout: 300000,
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
@@ -64,6 +65,6 @@ export default defineConfig({
     url: 'http://localhost:5173', // URL to wait for
     reuseExistingServer: !process.env.CI,
     cwd: './', // Assuming playwright.config.ts is in the frontend directory
-    timeout: 120 * 1000, // 2 minutes timeout for the server to start
+    timeout: 300000, // 5 minutes timeout for the server to start
   },
 });


### PR DESCRIPTION
## Summary
- allow longer tests by setting `testTimeout: 300000` in backend and frontend Jest configs
- extend Playwright's timeout settings to 5 minutes

## Testing
- `pnpm install && pnpm test` in `backend`
- `pnpm install && pnpm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_6859f6adc184832f933d45a757d9d4c1