### PR TITLE
Improve API client usage

### DIFF
--- a/frontend/src/components/clients/FicheClient.tsx
+++ b/frontend/src/components/clients/FicheClient.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 import { useNavigate, useParams, Link } from 'react-router-dom'
-import { API_URL } from '@/lib/api'
+import { apiClient } from '@/lib/api'
 import { Button } from '@/components/ui/button'
 import { Card } from '@/components/ui/card'
 import { Client } from './CarteClient'
@@ -12,8 +12,14 @@ export default function FicheClient() {
 
   useEffect(() => {
     ;(async () => {
-      const res = await fetch(`${API_URL}/clients/${id}`)
-      if (res.ok) setClient(await res.json())
+      if (id) {
+        try {
+          const data = await apiClient.getClient(Number(id))
+          setClient(data)
+        } catch (error) {
+          console.error('Erreur chargement client', error)
+        }
+      }
     })()
   }, [id])
 

--- a/frontend/src/components/clients/FormulaireClient.tsx
+++ b/frontend/src/components/clients/FormulaireClient.tsx
@@ -4,7 +4,7 @@ import { Input } from '@/components/ui/input'
 import { Textarea } from '@/components/ui/textarea'
 import { Label } from '@/components/ui/label'
 import { Button } from '@/components/ui/button'
-import { API_URL } from '@/lib/api'
+import { apiClient } from '@/lib/api'
 
 interface Props {
   onCreated?: () => void
@@ -25,10 +25,8 @@ export default function FormulaireClient({ onCreated }: Props) {
   const submit = async (e: FormEvent) => {
     e.preventDefault()
     if (!nom.trim()) return
-    const res = await fetch(`${API_URL}/clients`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
+    try {
+      await apiClient.createClient({
         nom_client: nom,
         prenom_client: prenom,
         nom_entreprise: entreprise,
@@ -40,8 +38,20 @@ export default function FormulaireClient({ onCreated }: Props) {
         tva,
         logo
       })
-    })
-    if (res.ok) {
+      setNom('')
+      setPrenom('')
+      setEntreprise('')
+      setTelephone('')
+      setEmail('')
+      setAdresseFact('')
+      setAdresseLiv('')
+      setSiret('')
+      setTva('')
+      setLogo('')
+      onCreated?.()
+    } catch (error) {
+      console.error('Erreur création client', error)
+    }
       setNom('')
       setPrenom('')
       setEntreprise('')

--- a/frontend/src/components/clients/ListeClients.tsx
+++ b/frontend/src/components/clients/ListeClients.tsx
@@ -2,18 +2,15 @@ import { useEffect, useState } from 'react'
 import FormulaireClient from './FormulaireClient'
 import CarteClient, { Client } from './CarteClient'
 import { Input } from '@/components/ui/input'
-import { API_URL } from '@/lib/api'
+import { apiClient } from '@/lib/api'
 
 export default function ListeClients() {
   const [clients, setClients] = useState<Client[]>([])
   const [search, setSearch] = useState('')
 
   const load = async () => {
-    const res = await fetch(`${API_URL}/clients`)
-    if (res.ok) {
-      const data = await res.json()
-      setClients(data)
-    }
+    const data = await apiClient.getClients()
+    setClients(data)
   }
 
   useEffect(() => {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -124,5 +124,65 @@ export const apiClient = {
     }
     return response.json();
   },
+
+  // ---------- Client API Helpers ----------
+
+  getClients: async (): Promise<any[]> => {
+    const token = getAuthToken();
+    const response = await fetch(`${API_URL}/clients`, {
+      headers: {
+        'Authorization': `Bearer ${token}`,
+      },
+    });
+    if (!response.ok) {
+      throw new Error(`Failed to fetch clients: ${response.statusText}`);
+    }
+    return response.json();
+  },
+
+  getClient: async (id: number): Promise<any> => {
+    const token = getAuthToken();
+    const response = await fetch(`${API_URL}/clients/${id}`, {
+      headers: {
+        'Authorization': `Bearer ${token}`,
+      },
+    });
+    if (!response.ok) {
+      throw new Error(`Failed to fetch client ${id}: ${response.statusText}`);
+    }
+    return response.json();
+  },
+
+  createClient: async (client: any): Promise<any> => {
+    const token = getAuthToken();
+    const response = await fetch(`${API_URL}/clients`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${token}`,
+      },
+      body: JSON.stringify(client),
+    });
+    if (!response.ok) {
+      throw new Error(`Failed to create client: ${response.statusText}`);
+    }
+    return response.json();
+  },
+
+  updateClient: async (id: number, client: any): Promise<any> => {
+    const token = getAuthToken();
+    const response = await fetch(`${API_URL}/clients/${id}`, {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${token}`,
+      },
+      body: JSON.stringify(client),
+    });
+    if (!response.ok) {
+      throw new Error(`Failed to update client ${id}: ${response.statusText}`);
+    }
+    return response.json();
+  },
   // ... other existing api client methods if any
 };

--- a/frontend/src/pages/Clients.tsx
+++ b/frontend/src/pages/Clients.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, FormEvent } from 'react'
 import { Plus, X, Edit, Save, ArrowLeft } from 'lucide-react'
 import { Link, useNavigate } from 'react-router-dom'
-import { API_URL } from '@/lib/api'
+import { API_URL, apiClient } from '@/lib/api'
 import {
   Card,
   CardHeader,
@@ -93,11 +93,8 @@ export default function Clients() {
 
 
   const chargerClients = async () => {
-    const res = await fetch(`${API_URL}/clients`)
-    if (res.ok) {
-      const data = await res.json()
-      setClients(data)
-    }
+    const data = await apiClient.getClients();
+    setClients(data);
   }
 
   useEffect(() => {
@@ -107,32 +104,28 @@ export default function Clients() {
   const creerClient = async (e: FormEvent) => {
     e.preventDefault()
     if (!nom.trim()) return
-    const res = await fetch(`${API_URL}/clients`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
+    try {
+      await apiClient.createClient({
         nom_client: nom,
         nom_entreprise: entreprise,
-        telephone, // Keep existing fields that are not in the new form spec but part of the model
-        email,     // Keep existing fields
-        intitule,  // Keep existing fields
-        siren,     // Keep existing fields
-        siret,     // Keep existing fields
-        legal_form: legalForm, // Keep existing fields
-        rcs_number: rcsNumber, // Keep existing fields
+        telephone,
+        email,
+        intitule,
+        siren,
+        siret,
+        legal_form: legalForm,
+        rcs_number: rcsNumber,
 
-        adresse_facturation_rue: adresseFacturationRue,
-        adresse_facturation_cp: adresseFacturationCp,
-        adresse_facturation_ville: adresseFacturationVille,
+      adresse_facturation_rue: adresseFacturationRue,
+      adresse_facturation_cp: adresseFacturationCp,
+      adresse_facturation_ville: adresseFacturationVille,
 
-        adresse_livraison_rue: adresseLivraisonIdentique ? adresseFacturationRue : adresseLivraisonRue,
-        adresse_livraison_cp: adresseLivraisonIdentique ? adresseFacturationCp : adresseLivraisonCp,
-        adresse_livraison_ville: adresseLivraisonIdentique ? adresseFacturationVille : adresseLivraisonVille,
+      adresse_livraison_rue: adresseLivraisonIdentique ? adresseFacturationRue : adresseLivraisonRue,
+      adresse_livraison_cp: adresseLivraisonIdentique ? adresseFacturationCp : adresseLivraisonCp,
+      adresse_livraison_ville: adresseLivraisonIdentique ? adresseFacturationVille : adresseLivraisonVille,
 
-        tva: tvaClient, // Numéro de TVA intracommunautaire (client)
-      })
-    })
-    if (res.ok) {
+      tva: tvaClient,
+      });
       toast({
         title: 'Client créé',
         description: `Le client ${nom} ${entreprise ? '('+entreprise+')' : ''} a été créé avec succès.`,
@@ -158,11 +151,10 @@ export default function Clients() {
 
       setShowForm(false)
       chargerClients()
-    } else {
-      const data = await res.json().catch(() => null)
+    } catch (error: any) {
       toast({
         title: 'Erreur de création',
-        description: data?.error || 'Erreur lors de la création du client.',
+        description: error.message || 'Erreur lors de la création du client.',
         variant: 'destructive',
       });
     }
@@ -172,10 +164,8 @@ export default function Clients() {
     e.preventDefault()
     if (editingId === null) return
     if (!editNom.trim()) return
-    const res = await fetch(`${API_URL}/clients/${editingId}`, {
-      method: 'PUT',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
+    try {
+      await apiClient.updateClient(editingId, {
         nom_client: editNom,
         nom_entreprise: editEntreprise,
         telephone: editTelephone,
@@ -195,9 +185,7 @@ export default function Clients() {
         adresse_livraison_ville: editAdresseLivraisonIdentique ? editAdresseFacturationVille : editAdresseLivraisonVille,
 
         tva: editTvaClient,
-      })
-    })
-    if (res.ok) {
+      });
       setEditingId(null)
       // Reset edit form states
       setEditNom('')
@@ -223,11 +211,10 @@ export default function Clients() {
         description: `Le client ${editNom} ${editEntreprise ? '('+editEntreprise+')' : ''} a été mis à jour.`,
       });
       navigate(`/clients/${editingId}`); // Redirect to the client's profile page
-    } else {
-      const data = await res.json().catch(() => null);
+    } catch (error: any) {
       toast({
         title: 'Erreur de mise à jour',
-        description: data?.error || 'Erreur lors de la mise à jour du client.',
+        description: error.message || 'Erreur lors de la mise à jour du client.',
         variant: 'destructive',
       });
     }

--- a/frontend/src/pages/CreerFacture.tsx
+++ b/frontend/src/pages/CreerFacture.tsx
@@ -146,15 +146,14 @@ export default function CreerFacture() {
 
       if(profileFetched) { // Only fetch clients if profile was fetched successfully
         try {
-          const clientsRes = await fetch(`${API_URL}/clients`); // TODO: Use apiClient if available for clients
-          if (clientsRes.ok) {
-            const clientsData = await clientsRes.json();
-            setClients(clientsData);
-          } else {
-            toast({ title: 'Erreur Chargement Clients', description: 'Impossible de charger la liste des clients.', variant: 'destructive' });
-          }
-        } catch (error) {
-          toast({ title: 'Erreur Réseau Clients', description: 'Impossible de joindre l\'API pour charger les clients.', variant: 'destructive' });
+          const clientsData = await apiClient.getClients();
+          setClients(clientsData);
+        } catch (error: any) {
+          toast({
+            title: 'Erreur Chargement Clients',
+            description: error.message || 'Impossible de charger la liste des clients.',
+            variant: 'destructive',
+          });
         }
       }
       setPageLoading(false);

--- a/frontend/src/pages/ModifierFacture.tsx
+++ b/frontend/src/pages/ModifierFacture.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useCallback } from 'react';
 import { useParams, useNavigate, Link } from 'react-router-dom';
 import { ArrowLeft, Plus, Trash2, Save, Calculator } from 'lucide-react';
 import LogoDropzone from '@/components/LogoDropzone';
-import { API_URL } from '@/lib/api';
+import { API_URL, apiClient } from '@/lib/api';
 import { computeTotals } from '@/lib/utils';
 
 interface LigneFacture {
@@ -84,11 +84,8 @@ export default function ModifierFacture() {
 
   useEffect(() => {
     const fetchClients = async () => {
-      const res = await fetch(`${API_URL}/clients`)
-      if (res.ok) {
-        const data = await res.json()
-        setClients(data)
-      }
+      const data = await apiClient.getClients();
+      setClients(data);
     }
     fetchClients()
   }, [])

--- a/frontend/src/pages/profiles/ClientProfile.tsx
+++ b/frontend/src/pages/profiles/ClientProfile.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
-import { API_URL } from '@/lib/api'
+import { apiClient } from '@/lib/api'
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card'
 import { ArrowLeft } from 'lucide-react'
 
@@ -38,11 +38,8 @@ export default function ClientProfile() {
 
   useEffect(() => {
     const fetchClient = async () => {
-      const res = await fetch(`${API_URL}/clients/${id}`)
-      if (res.ok) {
-        const data = await res.json()
-        setClient(data)
-      }
+      const data = await apiClient.getClient(Number(id))
+      setClient(data)
     }
     if (id) fetchClient()
   }, [id])


### PR DESCRIPTION
## Summary
- centralize client API calls in `apiClient`
- refactor pages and components to use new helpers

## Testing
- `pnpm test` in `backend`
- `pnpm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_685a086e81c0832f9e6b14188a7c0692