### PR TITLE
Add reusable ClientCard component

### DIFF
--- a/frontend/src/components/ClientCard.tsx
+++ b/frontend/src/components/ClientCard.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+
+export interface ClientType {
+  id: number;
+  nom_client: string;
+  nom_entreprise?: string;
+  email?: string;
+  telephone?: string;
+  siren?: string;
+  siret?: string;
+}
+
+interface ClientCardProps {
+  client: ClientType;
+}
+
+export const ClientCard: React.FC<ClientCardProps> = ({ client }) => (
+  <div className="border rounded p-4 space-y-1">
+    <h3 className="text-lg font-semibold">{client.nom_client}</h3>
+    {client.nom_entreprise && <div>{client.nom_entreprise}</div>}
+    {client.email && <div>Email : {client.email}</div>}
+    {client.telephone && <div>Téléphone : {client.telephone}</div>}
+    {client.siren && <div>SIREN : {client.siren}</div>}
+    {client.siret && <div>SIRET : {client.siret}</div>}
+  </div>
+);


### PR DESCRIPTION
## Summary
- implement a small `ClientCard` component for displaying basic client details

## Testing
- `cd backend && pnpm install && pnpm test`
- `cd frontend && pnpm install && pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_685a0c179328832f8081235a42f0f0cd