### PR TITLE
Invoice service and status badge

### DIFF
--- a/backend/invoiceHTML.ts
+++ b/backend/invoiceHTML.ts
@@ -24,6 +24,7 @@ export interface InvoiceData {
   date_reglement: string;
   date_vente: string;
   penalites: string;
+  status?: 'paid' | 'unpaid';
 }
 
 const ligneSchema = z.object({
@@ -47,6 +48,7 @@ const invoiceSchema = z.object({
   date_reglement: z.string(),
   date_vente: z.string(),
   penalites: z.string(),
+  status: z.enum(['paid','unpaid']).optional(),
 });
 
 
@@ -94,6 +96,7 @@ table.lines td.price, .totals p{ text-align:right; }
     <h1>FACTURE</h1>
     <p>N° ${parsed.numero}</p>
     <p>Date : ${dateStr}</p>
+    <p>Statut : ${parsed.status === 'paid' ? 'Payée' : 'Non payée'}</p>
   </section>
 </header>
 <section class="addresses">

--- a/backend/server.ts
+++ b/backend/server.ts
@@ -757,6 +757,7 @@ app.get('/api/factures/:id/html', async (req, res) => { // Made async
         date_reglement: mappedData.date_emission, // Placeholder: using emission date
         date_vente: mappedData.date_prestation,  // Placeholder: using prestation date
         penalites: "Pénalités de retard : Taux d'intérêt légal majoré de 10 points. Pas d'escompte pour paiement anticipé.", // Standard penalty clause
+        status: facture.status,
       };
 
       if (userProfile && userProfile.logo_path && !invoiceDataForTs.logo_path) {

--- a/frontend/src/components/StatutBadge.tsx
+++ b/frontend/src/components/StatutBadge.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+interface StatutBadgeProps {
+  statut: 'payée' | 'non payée';
+}
+
+const StatutBadge: React.FC<StatutBadgeProps> = ({ statut }) => {
+  const base = 'px-2 py-1 text-sm font-semibold rounded-full';
+  const styles = {
+    'payée': 'bg-green-100 text-green-800',
+    'non payée': 'bg-red-100 text-red-800',
+  } as const;
+
+  return (
+    <span className={`${base} ${styles[statut]}`}>{statut === 'payée' ? '✔️ Payée' : '❌ Non payée'}</span>
+  );
+};
+
+export default StatutBadge;

--- a/frontend/src/pages/DetailFacture.tsx
+++ b/frontend/src/pages/DetailFacture.tsx
@@ -7,6 +7,7 @@ import { toast } from '@/hooks/use-toast';
 import { computeTotals } from '@/lib/utils';
 import { format } from 'date-fns';
 import { fr } from 'date-fns/locale';
+import StatutBadge from '@/components/StatutBadge';
 
 interface Facture {
   id: number;
@@ -284,9 +285,7 @@ export default function DetailFacture() {
                       <FileText className="h-5 w-5 text-gray-400 mr-3" />
                       <div>
                         <p className="text-sm text-gray-500">Statut</p>
-                        <p className="font-semibold text-gray-900">
-                          {facture.status === 'paid' ? 'Payée' : 'Non payée'}
-                        </p>
+                        <StatutBadge statut={facture.status === 'paid' ? 'payée' : 'non payée'} />
                       </div>
                     </div>
                   )}

--- a/frontend/src/pages/ListeFactures.test.tsx
+++ b/frontend/src/pages/ListeFactures.test.tsx
@@ -45,7 +45,7 @@ test('marque une facture comme payée', async () => {
   await waitFor(() =>
     expect(fetch as any).toHaveBeenCalledWith(
       expect.stringContaining('/factures/1'),
-      expect.objectContaining({ method: 'PUT' })
+      expect.objectContaining({ method: 'PATCH' })
     )
   );
 });

--- a/frontend/src/pages/ListeFactures.tsx
+++ b/frontend/src/pages/ListeFactures.tsx
@@ -22,6 +22,12 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { API_URL } from '@/lib/api';
 import { toast } from '@/hooks/use-toast';
+import StatutBadge from '@/components/StatutBadge';
+import {
+  fetchInvoices,
+  updateInvoiceStatus,
+  cacheInvoicesLocally,
+} from '@/utils/invoiceService';
 
 interface Facture {
   id: number;
@@ -160,22 +166,13 @@ export default function ListeFactures() {
 
   const marquerPayee = async (id: number) => {
     try {
-      const response = await fetch(`${API_URL}/factures/${id}`, {
-        method: "PUT",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ statut: "payée" })
-      });
-      if (!response.ok) {
-        throw new Error("Erreur lors du changement de statut");
-      }
-      const updatedFacture = await response.json();
+      await updateInvoiceStatus(id, 'payée');
       setFactures(prev => {
         const updated = prev.map(f =>
-          f.id === id ? { ...f, status: updatedFacture.status } : f
+          f.id === id ? { ...f, status: 'paid' } : f
         );
-        return statusFilter === "unpaid"
-          ? updated.filter(f => f.id !== id)
-          : updated;
+        cacheInvoicesLocally(updated);
+        return statusFilter === 'unpaid' ? updated.filter(f => f.id !== id) : updated;
       });
     } catch (err) {
       alert(err instanceof Error ? err.message : "Erreur inattendue");
@@ -397,7 +394,7 @@ export default function ListeFactures() {
                           {facture.date_facture_fr}
                         </td>
                         <td className="px-6 py-4 whitespace-nowrap text-sm">
-                          {facture.status === 'paid' ? 'Payée' : 'Non payée'}
+                          <StatutBadge statut={facture.status === 'paid' ? 'payée' : 'non payée'} />
                         </td>
                         <td className="px-6 py-4 whitespace-nowrap">
                           <span className="text-lg font-semibold text-green-600">

--- a/frontend/src/pages/ModifierFacture.tsx
+++ b/frontend/src/pages/ModifierFacture.tsx
@@ -4,6 +4,7 @@ import { ArrowLeft, Plus, Trash2, Save, Calculator } from 'lucide-react';
 import LogoDropzone from '@/components/LogoDropzone';
 import { API_URL, apiClient } from '@/lib/api';
 import { computeTotals } from '@/lib/utils';
+import { updateInvoice, cacheInvoicesLocally } from '@/utils/invoiceService';
 
 interface LigneFacture {
   description: string;
@@ -244,35 +245,26 @@ export default function ModifierFacture() {
         ligne.description.trim() && ligne.quantite > 0 && ligne.prix_unitaire >= 0
       );
 
-      const response = await fetch(`${API_URL}/factures/${id}`, {
-        method: 'PUT',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
-          numero_facture: numeroFacture.trim(),
-          client_id: clientId || undefined,
-          nom_client: nomClient.trim(),
-          nom_entreprise: nomEntreprise.trim(),
-          telephone: telephone.trim(),
-          adresse: adresse.trim(),
-          date_facture: dateFacture,
-          title: title.trim(),
-          status,
-          logo_path: logoPath.trim(),
-          siren: siren.trim(),
-          siret: siret.trim(),
-          legal_form: legalForm.trim(),
-          vat_number: vatNumber.trim(),
-          rcs_number: rcsNumber.trim(),
-          lignes: lignesValides
-        }),
+      await updateInvoice(Number(id), {
+        numero_facture: numeroFacture.trim(),
+        client_id: clientId || undefined,
+        nom_client: nomClient.trim(),
+        nom_entreprise: nomEntreprise.trim(),
+        telephone: telephone.trim(),
+        adresse: adresse.trim(),
+        date_facture: dateFacture,
+        title: title.trim(),
+        status,
+        logo_path: logoPath.trim(),
+        siren: siren.trim(),
+        siret: siret.trim(),
+        legal_form: legalForm.trim(),
+        vat_number: vatNumber.trim(),
+        rcs_number: rcsNumber.trim(),
+        lignes: lignesValides,
       });
 
-      if (!response.ok) {
-        const errorData = await response.json();
-        throw new Error(errorData.details || 'Erreur lors de la modification de la facture');
-      }
+      cacheInvoicesLocally([]);
 
       alert('Facture modifiée avec succès !');
       navigate(`/factures/${id}`);

--- a/frontend/src/utils/invoiceService.ts
+++ b/frontend/src/utils/invoiceService.ts
@@ -1,0 +1,69 @@
+import { API_URL } from '@/lib/api';
+
+export interface InvoiceType {
+  id: number;
+  numero_facture: string;
+  nom_client: string;
+  nom_entreprise?: string;
+  status?: 'paid' | 'unpaid';
+  [key: string]: any;
+}
+
+const LOCAL_KEY = 'invoicesCache';
+
+export async function fetchInvoices(): Promise<InvoiceType[]> {
+  const res = await fetch(`${API_URL}/factures`);
+  if (!res.ok) throw new Error('Failed to fetch invoices');
+  const data = await res.json();
+  const invoices: InvoiceType[] = data.factures || data;
+  cacheInvoicesLocally(invoices);
+  return invoices;
+}
+
+export async function fetchInvoiceById(id: number): Promise<InvoiceType> {
+  const res = await fetch(`${API_URL}/factures/${id}`);
+  if (!res.ok) throw new Error('Failed to fetch invoice');
+  const invoice = await res.json();
+  return invoice as InvoiceType;
+}
+
+export async function updateInvoice(id: number, data: Partial<InvoiceType>): Promise<void> {
+  await fetch(`${API_URL}/factures/${id}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data),
+  });
+}
+
+export async function updateInvoiceStatus(
+  id: number,
+  status: 'payée' | 'non payée'
+): Promise<void> {
+  await fetch(`${API_URL}/factures/${id}/status`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ status: status === 'payée' ? 'paid' : 'unpaid' }),
+  });
+}
+
+export function cacheInvoicesLocally(invoices: InvoiceType[]): void {
+  try {
+    if (typeof window !== 'undefined') {
+      localStorage.setItem(LOCAL_KEY, JSON.stringify(invoices));
+    }
+  } catch {
+    /* ignore */
+  }
+}
+
+export function getInvoiceFromLocal(id: number): InvoiceType | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    const stored = localStorage.getItem(LOCAL_KEY);
+    if (!stored) return null;
+    const invoices: InvoiceType[] = JSON.parse(stored);
+    return invoices.find((f) => f.id === id) || null;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- add `invoiceService` utilities for API calls and caching
- add `StatutBadge` for displaying invoice status
- show `StatutBadge` in invoice list and details
- support status in HTML export
- update invoice update logic and tests

## Testing
- `cd backend && pnpm install && pnpm test`
- `cd frontend && pnpm install && pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_685a0de3f93c832f8170543b10415e76