### PR TITLE
Fix backend build and update playwright

### DIFF
--- a/ANALYSE_POST_REFACTO.md
+++ b/ANALYSE_POST_REFACTO.md
@@ -1,0 +1,13 @@
+# Analyse Post-Refacto
+
+## ✅ Fonctionnel
+- Les tests unitaires backend et frontend passent.
+- Structure du cache local pour les factures et le profil utilisateur cohérente.
+
+## ⚠️ Correctifs apportés
+- Ajout de `@types/node` et mise à jour de `tsconfig.json` pour compiler correctement le backend.
+- Modification de `playwright.config.ts` pour démarrer le frontend et le backend lors des tests E2E.
+
+## 🚧 À optimiser
+- Les tests E2E Playwright échouent encore : compilation du backend en mode dev pose problème et nécessite un nettoyage plus poussé des types.
+- Vérifier la cohérence de certaines propriétés (`emitter_*`) dans `server.ts`.

--- a/backend/package.json
+++ b/backend/package.json
@@ -25,6 +25,7 @@
     "zod": "^3.24.1"
   },
   "devDependencies": {
+    "@types/node": "^24.0.3",
     "@types/numeral": "^2.0.5",
     "jest": "^29.6.1",
     "nodemon": "^3.0.1",

--- a/backend/pnpm-lock.yaml
+++ b/backend/pnpm-lock.yaml
@@ -45,6 +45,9 @@ importers:
         specifier: ^3.24.1
         version: 3.25.67
     devDependencies:
+      '@types/node':
+        specifier: ^24.0.3
+        version: 24.0.3
       '@types/numeral':
         specifier: ^2.0.5
         version: 2.0.5

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -7,6 +7,7 @@
     "strict": false, // Keeping as per original, though true is generally better
     "skipLibCheck": true,
     "resolveJsonModule": true,
+    "types": ["node"],
     "outDir": "dist" // Optional: for manual tsc builds
   },
   "include": ["**/*.ts"], // Broader include for all .ts files in backend

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -60,11 +60,21 @@ export default defineConfig({
   ],
 
   /* Run your local dev server before starting the tests */
-  webServer: {
-    command: 'pnpm run dev', // Command to start the frontend dev server
-    url: 'http://localhost:5173', // URL to wait for
-    reuseExistingServer: !process.env.CI,
-    cwd: './', // Assuming playwright.config.ts is in the frontend directory
-    timeout: 300000, // 5 minutes timeout for the server to start
-  },
+  // Launch frontend and backend dev servers for E2E tests
+  webServer: [
+    {
+      command: 'pnpm run dev',
+      port: 5173,
+      reuseExistingServer: !process.env.CI,
+      cwd: './',
+      timeout: 300000,
+    },
+    {
+      command: 'pnpm start',
+      port: 3001,
+      reuseExistingServer: !process.env.CI,
+      cwd: '../backend',
+      timeout: 300000,
+    },
+  ],
 });


### PR DESCRIPTION
## Summary
- update backend TypeScript config and add `@types/node`
- modify Playwright config to start both dev servers for tests
- add post-refactor analysis report

## Testing
- `pnpm test` in `backend/`
- `pnpm test` in `frontend/`
- `pnpm exec playwright test --project=chromium` *(fails: backend build issues)*

------
https://chatgpt.com/codex/tasks/task_e_685a0fc91b84832fb6104281d91ef8f4