### PR TITLE
Fix ts-jest configuration

### DIFF
--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -6,11 +6,14 @@ export default {
     '^@/(.*)$': '<rootDir>/src/$1',
   },
   extensionsToTreatAsEsm: ['.ts', '.tsx'],
-  globals: {
-    'ts-jest': {
-      tsconfig: './tsconfig.app.json',
-      useESM: true,
-    },
+  transform: {
+    '^.+\\.(ts|tsx)$': [
+      'ts-jest',
+      {
+        tsconfig: './tsconfig.app.json',
+        useESM: true,
+      },
+    ],
   },
   // Babel config is removed as it wasn't solving the import.meta issue correctly
   // and we are now mocking the modules that use import.meta.env.


### PR DESCRIPTION
## Summary
- update frontend jest.config.js to use recommended `transform` option instead of deprecated `globals`

## Testing
- `cd backend && pnpm install && pnpm test`
- `cd frontend && pnpm install && pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_685a157c3548832f9c715709831bcd2d