### PR TITLE
Refactor auth token handling in frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,8 +130,19 @@ index 8d1b612983393f38db689b807e29214e58809767..32c76047b2de5043fe0a5f364c1592b9
  
  - **Production** : définir la variable lors du build ou sur votre hébergeur
    ```bash
-     VITE_API_URL=https://mon-domaine.com/api pnpm run build
-     ```
+    VITE_API_URL=https://mon-domaine.com/api pnpm run build
+    ```
+
+### Jeton d'API
+
+Le frontend lit un jeton nommé `apiToken` depuis le `localStorage` du navigateur.
+Pour développer ou lancer les tests, définissez ce jeton :
+
+```js
+localStorage.setItem('apiToken', 'test-token');
+```
+
+Les suites Jest et Playwright le positionnent automatiquement avec cette valeur.
  
  ### Génération locale
  

--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -15,6 +15,7 @@ export default {
       },
     ],
   },
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
   // Babel config is removed as it wasn't solving the import.meta issue correctly
   // and we are now mocking the modules that use import.meta.env.
   testPathIgnorePatterns: [

--- a/frontend/jest.setup.ts
+++ b/frontend/jest.setup.ts
@@ -1,0 +1,3 @@
+beforeAll(() => {
+  localStorage.setItem('apiToken', 'test-token');
+});

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -81,7 +81,7 @@ const getAuthToken = () => {
   // This matches the simple token check in backend/server.js (process.env.API_TOKEN)
   // Replace 'your_static_api_token' with the actual token if it's static,
   // or implement proper token retrieval.
-  return localStorage.getItem('apiToken') || 'TEST_TOKEN_FROM_FRONTEND';
+  return localStorage.getItem('apiToken') || '';
 };
 
 export const apiClient = {

--- a/frontend/tests/e2e/app.spec.ts
+++ b/frontend/tests/e2e/app.spec.ts
@@ -6,6 +6,9 @@ const INVOICE_SUBJECT_E2E = 'E2E Test Invoice Subject';
 
 test.describe('Mam-s-Facture E2E Tests', () => {
   test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => {
+      window.localStorage.setItem('apiToken', 'test-token');
+    });
     await page.goto('/');
   });
 


### PR DESCRIPTION
## Summary
- read API token only from `localStorage`
- make frontend tests initialize the token via setup file
- persist auth token in e2e tests
- document how to set `apiToken` for development and testing

## Testing
- `cd backend && pnpm install && pnpm test`
- `cd frontend && pnpm install && pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_685ad8f9aec0832fbbddb52d608e1b01