### PR TITLE
Implement centralized error handling

### DIFF
--- a/backend/middleware/errorHandler.ts
+++ b/backend/middleware/errorHandler.ts
@@ -1,0 +1,7 @@
+import { Request, Response, NextFunction } from 'express';
+
+export const errorHandler = (err: any, _req: Request, res: Response, _next: NextFunction) => {
+  const status = err.status || 500;
+  const message = err.message || 'Internal Server Error';
+  res.status(status).json({ error: message });
+};

--- a/backend/tests/errors.test.js
+++ b/backend/tests/errors.test.js
@@ -1,0 +1,35 @@
+jest.mock('../services/quoteService', () => ({
+  getRandomQuote: jest.fn(() => { throw new Error('boom'); })
+}));
+const request = require('supertest');
+let app;
+
+beforeAll(async () => {
+  app = await require('../server');
+});
+
+const API_TOKEN = 'test-token';
+
+describe('Error handling', () => {
+  test('GET missing client returns 404', async () => {
+    const res = await request(app)
+      .get('/api/clients/999999')
+      .set('Authorization', `Bearer ${API_TOKEN}`);
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe('Client non trouvé');
+  });
+
+  test('GET missing invoice returns 404', async () => {
+    const res = await request(app)
+      .get('/api/factures/999999')
+      .set('Authorization', `Bearer ${API_TOKEN}`);
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe('Facture non trouvée');
+  });
+
+  test('server error propagates to middleware', async () => {
+    const res = await request(app).get('/api/quote');
+    expect(res.status).toBe(500);
+    expect(res.body.error).toBe('Erreur lors de la récupération de la citation');
+  });
+});


### PR DESCRIPTION
## Summary
- add new error-handler middleware for backend
- route 500 errors through middleware via `next()`
- wire middleware into server
- add tests covering API error cases

## Testing
- `pnpm install` and `pnpm test` in `backend`
- `pnpm install` and `pnpm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_685ad888cf68832fb2745e98ed4a199a