### PR TITLE
Add CI workflow for tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: 'pnpm'
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 8
+          run_install: false
+      - name: Install and test backend
+        working-directory: backend
+        run: |
+          pnpm install
+          pnpm test
+      - name: Install and test frontend
+        working-directory: frontend
+        run: |
+          pnpm install
+          pnpm test


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow that installs Node and pnpm
- run `pnpm install && pnpm test` for backend and frontend on pushes to `main` and pull requests

## Testing
- `cd backend && pnpm install && pnpm test`
- `cd frontend && pnpm install && pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_685ad8687dec832f8ebec5ae7eb792bc