### PR TITLE
Add UI test generation capability

### DIFF
--- a/docs/agent.md
+++ b/docs/agent.md
@@ -1,0 +1,23 @@
+# Agent CLI
+
+Ce document decrit le fonctionnement de l'agent automatique utilisé dans le projet.
+
+---
+
+## 🔁 Mise à jour du 24/06/2025 – Génération automatique de tests UI
+
+### Nouvelle fonctionnalité :
+L’agent IA détecte désormais les tâches liées à l’interface utilisateur (UI) dans le fichier `docs/TODO.md`, et génère automatiquement un fichier de test unitaire à l’aide d’un prompt intelligent envoyé à Codex.
+
+### Fonctionnement :
+- Lorsqu’une tâche contient des mots-clés liés à l’UI (ex : "badge", "affichage", "clic", "composant", etc.), l’agent déclenche un générateur de test.
+- Le test est créé dans un fichier `.test.tsx` dans le dossier `__tests__/`
+- Il utilise `@testing-library/react`
+- Il inclut une limite de temps (`jest.setTimeout(5000)`) pour éviter les blocages
+
+### Exemple de tâche déclencheuse :
+
+	•	UI – corriger le badge de statut “Payée”
+
+### Objectif :
+Maximiser la couverture des tests sur tous les composants interactifs de l’application, de manière autonome.

--- a/scripts/agent.ts
+++ b/scripts/agent.ts
@@ -1,5 +1,6 @@
 // scripts/agent.ts
 import fs from 'fs';
+import { writeFileSync } from 'fs';
 import path from 'path';
 import { execSync } from 'child_process';
 
@@ -11,6 +12,53 @@ const CHANGELOG_PATH = path.resolve(__dirname, '../docs/CHANGELOG.md');
 const readFile = (p: string) => fs.existsSync(p) ? fs.readFileSync(p, 'utf8') : '';
 const writeFile = (p: string, content: string) => fs.writeFileSync(p, content, 'utf8');
 const appendFile = (p: string, content: string) => fs.appendFileSync(p, content + '\n', 'utf8');
+
+// === AJOUT : Détection et génération de test UI ===
+
+function isUITask(task: string): boolean {
+  const uiKeywords = ['UI', 'interface', 'affichage', 'bouton', 'visuel', 'clic', 'badge', 'composant'];
+  return uiKeywords.some(kw => task.toLowerCase().includes(kw));
+}
+
+function getCodexPromptForUITest(componentName: string, behavior: string) {
+  return `
+# Mission
+G\u00e9n\u00e8re un fichier de test UI automatique en TypeScript utilisant @testing-library/react.
+
+## Composant concern\u00e9
+Nom : ${componentName}
+
+## Comportement attendu
+${behavior}
+
+## Contraintes
+- Utiliser un fichier .test.tsx
+- Simuler les interactions utilisateur (clics, changements d\u2019\u00e9tat)
+- Ajouter une gestion de timeout pour \u00e9viter les tests bloqu\u00e9s (ex: jest.setTimeout(5000))
+- Utiliser des assertions claires
+- Ne pas inclure d'import inutile
+
+# Exemple :
+import { render, screen, fireEvent } from '@testing-library/react';
+jest.setTimeout(5000);
+
+// ... test code ici ...
+`;
+}
+
+async function fetchCodexCompletion(prompt: string): Promise<string> {
+  // Stub – to be replaced with real Codex call
+  return `// Codex output for: ${prompt}`;
+}
+
+// Appel Codex (stub à remplacer si Codex branché en local ou API)
+async function generateUITestFile(task: string, componentName: string) {
+  const prompt = getCodexPromptForUITest(componentName, task);
+  const output = await fetchCodexCompletion(prompt); // <- remplacer avec ta logique Codex
+  const filename = `__tests__/${componentName}.test.tsx`;
+  writeFileSync(filename, output, 'utf-8');
+  console.log(`✅ Test g\u00e9n\u00e9r\u00e9 : ${filename}`);
+}
 
 // === PARSE TO-DO ===
 function extractTasks(todoText: string): { section: string, task: string }[] {
@@ -39,6 +87,11 @@ async function run() {
 
   console.log(`🚀 Lancement de la tâche : ${task.task}`);
   execSync(`git checkout -b ${branch}`);
+
+  if (isUITask(task.task)) {
+    const component = task.task.split(' ')[1] || 'Component'; // Ex: "Fix badge UI"
+    await generateUITestFile(task.task, component);
+  }
 
   // Simule une action (à remplacer par ton implémentation réelle)
   appendFile(CHANGELOG_PATH, `- ✅ ${task.task} [${task.section}]`);


### PR DESCRIPTION
## Summary
- extend `agent.ts` to detect UI tasks and stub Codex prompt generation
- document automated UI test generation in `docs/agent.md`

## Testing
- `pnpm install` and `pnpm test` in `backend`
- `pnpm install` and `pnpm test` in `frontend`

------
https://chatgpt.com/codex/tasks/task_e_685ae16cd67c832f885ef385523bbef4