### PR TITLE
Fix pnpm setup in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,8 +14,6 @@ jobs:
         with:
           node-version: 18
           cache: 'pnpm'
-      - name: Install pnpm
-        run: npm install -g pnpm
       - uses: pnpm/action-setup@v2
         with:
           version: 8


### PR DESCRIPTION
## Summary
- use pnpm/action-setup to install pnpm
- remove manual npm install step

## Testing
- `cd backend && pnpm install && pnpm test`
- `cd frontend && pnpm install && pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_685b83b76884832fb6557cd3536e4f6b