### PR TITLE
Fix invoice list refresh after status change

### DIFF
--- a/frontend/src/pages/ListeFactures.tsx
+++ b/frontend/src/pages/ListeFactures.tsx
@@ -104,6 +104,12 @@ export default function ListeFactures() {
   }, [chargerFactures]);
 
   useEffect(() => {
+    const handler = () => chargerFactures();
+    window.addEventListener('invoiceStatusChanged', handler);
+    return () => window.removeEventListener('invoiceStatusChanged', handler);
+  }, [chargerFactures]);
+
+  useEffect(() => {
     const params = new URLSearchParams(location.search);
     const st = params.get('status');
     const statut = params.get('statut');
@@ -174,6 +180,7 @@ export default function ListeFactures() {
         cacheInvoicesLocally(updated);
         return statusFilter === 'unpaid' ? updated.filter(f => f.id !== id) : updated;
       });
+      window.dispatchEvent(new Event('invoiceStatusChanged'));
     } catch (err) {
       alert(err instanceof Error ? err.message : "Erreur inattendue");
     }


### PR DESCRIPTION
## Summary
- fire a global `invoiceStatusChanged` event when a bill is marked as paid
- refresh invoice lists when that event is received

## Testing
- `cd backend && pnpm install && pnpm test`
- `cd frontend && pnpm install && pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_685b88526310832fb0054b7e6910b642