### PR TITLE
Fix invoice status change

### DIFF
--- a/frontend/src/pages/ListeFactures.test.tsx
+++ b/frontend/src/pages/ListeFactures.test.tsx
@@ -44,7 +44,7 @@ test('marque une facture comme payée', async () => {
 
   await waitFor(() =>
     expect(fetch as any).toHaveBeenCalledWith(
-      expect.stringContaining('/factures/1'),
+      expect.stringContaining('/factures/1/update'),
       expect.objectContaining({ method: 'PATCH' })
     )
   );

--- a/frontend/src/pages/ListeFactures.tsx
+++ b/frontend/src/pages/ListeFactures.tsx
@@ -105,8 +105,8 @@ export default function ListeFactures() {
 
   useEffect(() => {
     const handler = () => chargerFactures();
-    window.addEventListener('invoiceStatusChanged', handler);
-    return () => window.removeEventListener('invoiceStatusChanged', handler);
+    window.addEventListener('factureStatutChange', handler);
+    return () => window.removeEventListener('factureStatutChange', handler);
   }, [chargerFactures]);
 
   useEffect(() => {
@@ -172,17 +172,19 @@ export default function ListeFactures() {
 
   const marquerPayee = async (id: number) => {
     try {
-      await updateInvoiceStatus(id, 'payée');
+      const updated = await updateInvoiceStatus(id, 'payée');
       setFactures(prev => {
-        const updated = prev.map(f =>
-          f.id === id ? { ...f, status: 'paid' } : f
-        );
-        cacheInvoicesLocally(updated);
-        return statusFilter === 'unpaid' ? updated.filter(f => f.id !== id) : updated;
+        const list = prev.map(f => (f.id === id ? updated : f));
+        cacheInvoicesLocally(list);
+        return statusFilter === 'unpaid' ? list.filter(f => f.id !== id) : list;
       });
-      window.dispatchEvent(new Event('invoiceStatusChanged'));
+      toast({ description: 'Statut mis à jour' });
+      window.dispatchEvent(new Event('factureStatutChange'));
     } catch (err) {
-      alert(err instanceof Error ? err.message : "Erreur inattendue");
+      toast({
+        description: err instanceof Error ? err.message : 'Erreur lors de la mise à jour',
+        variant: 'destructive'
+      });
     }
   };
 

--- a/frontend/src/utils/invoiceService.ts
+++ b/frontend/src/utils/invoiceService.ts
@@ -38,12 +38,16 @@ export async function updateInvoice(id: number, data: Partial<InvoiceType>): Pro
 export async function updateInvoiceStatus(
   id: number,
   status: 'payée' | 'non payée'
-): Promise<void> {
-  await fetch(`${API_URL}/factures/${id}/status`, {
+): Promise<InvoiceType> {
+  const res = await fetch(`${API_URL}/factures/${id}/update`, {
     method: 'PATCH',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ status: status === 'payée' ? 'paid' : 'unpaid' }),
   });
+  if (!res.ok) {
+    throw new Error('Failed to update invoice status');
+  }
+  return (await res.json()) as InvoiceType;
 }
 
 export function cacheInvoicesLocally(invoices: InvoiceType[]): void {


### PR DESCRIPTION
## Summary
- use `/api/factures/:id/update` when changing invoice status
- refresh invoice list on `factureStatutChange` events
- display toast notifications when the status update succeeds or fails
- update tests for new endpoint

## Testing
- `cd backend && pnpm install && pnpm test`
- `cd frontend && pnpm install && pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_685b900c87f4832f80e000c10b8d45ec