### PR TITLE
Fix: Correct updateInvoiceStatus helper URL and add notifications

### DIFF
--- a/frontend/src/utils/invoiceService.ts
+++ b/frontend/src/utils/invoiceService.ts
@@ -1,4 +1,5 @@
 import { API_URL } from '@/lib/api';
+import { toast } from '@/hooks/use-toast';
 
 export interface InvoiceType {
   id: number;
@@ -37,17 +38,49 @@ export async function updateInvoice(id: number, data: Partial<InvoiceType>): Pro
 
 export async function updateInvoiceStatus(
   id: number,
-  status: 'payée' | 'non payée'
+  newStatus: 'paid' | 'unpaid' // Changed type to match example and backend expectation
 ): Promise<InvoiceType> {
-  const res = await fetch(`${API_URL}/factures/${id}/update`, {
+  const res = await fetch(`${API_URL}/factures/${id}/status`, { // Corrected URL
     method: 'PATCH',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ status: status === 'payée' ? 'paid' : 'unpaid' }),
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ status: newStatus }), // Use newStatus directly
   });
+
   if (!res.ok) {
-    throw new Error('Failed to update invoice status');
+    // Attempt to get error message from backend response
+    let errorMessage = 'Erreur lors de la mise à jour du statut';
+    try {
+      const errorData = await res.json();
+      if (errorData && errorData.message) {
+        errorMessage = errorData.message;
+      }
+    } catch (e) {
+      // Ignore if response is not JSON or other error
+    }
+    toast({
+      title: "Erreur de mise à jour",
+      description: errorMessage,
+      variant: "destructive",
+    });
+    throw new Error(errorMessage);
   }
-  return (await res.json()) as InvoiceType;
+
+  const updatedInvoice = (await res.json()) as InvoiceType;
+
+  // Affiche une confirmation
+  toast({
+    title: "Statut mis à jour",
+    description: `Le statut de la facture #${updatedInvoice.numero_facture} est maintenant ${newStatus === 'paid' ? 'payée' : 'non payée'}.`,
+  });
+
+  // Déclenche l’événement global
+  window.dispatchEvent(new CustomEvent('factureStatutChange', {
+    detail: updatedInvoice,
+  }));
+
+  return updatedInvoice;
 }
 
 export function cacheInvoicesLocally(invoices: InvoiceType[]): void {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "build:backend": "cd backend && pnpm run build",
     "build:electron": "pnpm exec tsc -p electron/tsconfig.json",
     "build": "pnpm run build:web && pnpm run build:backend && pnpm run build:electron && electron-builder",
-    "start": "pnpm run build:web && pnpm run build:backend && pnpm run build:electron && electron ."
+    "start": "pnpm run build:web && pnpm run build:backend && pnpm run build:electron && electron .",
+    "dev:all": "concurrently \"cd backend && pnpm dev\" \"cd frontend && pnpm dev\""
   },
   "dependencies": {
     "playwright": "^1.53.1"
@@ -14,6 +15,7 @@
   "devDependencies": {
     "@types/electron": "^1.6.12",
     "@types/node": "^24.0.3",
+    "concurrently": "^9.2.0",
     "electron": "^28.2.3",
     "electron-builder": "^26.0.12",
     "ts-node": "^10.9.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,9 @@ importers:
       '@types/node':
         specifier: ^24.0.3
         version: 24.0.3
+      concurrently:
+        specifier: ^9.2.0
+        version: 9.2.0
       electron:
         specifier: ^28.2.3
         version: 28.3.3
@@ -413,6 +416,11 @@ packages:
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
+  concurrently@9.2.0:
+    resolution: {integrity: sha512-IsB/fiXTupmagMW4MNp2lx2cdSN2FfZq78vF90LBB+zZHArbIQZjQtzXCiXnvTxCZSvXanTqFLWBjw2UkLx1SQ==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   config-file-ts@0.2.8-rc1:
     resolution: {integrity: sha512-GtNECbVI82bT4RiDIzBSVuTKoSHufnU7Ce7/42bkWZJZFLjmDF2WBpVsvRkhKCfKBnTBb3qZrBwPpFBU/Myvhg==}
@@ -1137,6 +1145,9 @@ packages:
     resolution: {integrity: sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==}
     engines: {node: '>=8.0'}
 
+  rxjs@7.8.2:
+    resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
+
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
@@ -1176,6 +1187,10 @@ packages:
   shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
+
+  shell-quote@1.8.3:
+    resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
+    engines: {node: '>= 0.4'}
 
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
@@ -1249,6 +1264,10 @@ packages:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
 
+  supports-color@8.1.1:
+    resolution: {integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==}
+    engines: {node: '>=10'}
+
   tar@6.2.1:
     resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
     engines: {node: '>=10'}
@@ -1270,6 +1289,10 @@ packages:
     resolution: {integrity: sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w==}
     engines: {node: '>=14.14'}
 
+  tree-kill@1.2.2:
+    resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
+    hasBin: true
+
   truncate-utf8-bytes@1.0.2:
     resolution: {integrity: sha512-95Pu1QXQvruGEhv62XCMO3Mm90GscOCClvrIUwCM0PYOXK3kaF3l3sIHxx71ThJfcbM2O5Au6SO3AWCSEfW4mQ==}
 
@@ -1286,6 +1309,9 @@ packages:
         optional: true
       '@swc/wasm':
         optional: true
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
   type-fest@0.13.1:
     resolution: {integrity: sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==}
@@ -1893,6 +1919,16 @@ snapshots:
   compare-version@0.1.2: {}
 
   concat-map@0.0.1: {}
+
+  concurrently@9.2.0:
+    dependencies:
+      chalk: 4.1.2
+      lodash: 4.17.21
+      rxjs: 7.8.2
+      shell-quote: 1.8.3
+      supports-color: 8.1.1
+      tree-kill: 1.2.2
+      yargs: 17.7.2
 
   config-file-ts@0.2.8-rc1:
     dependencies:
@@ -2704,6 +2740,10 @@ snapshots:
       sprintf-js: 1.1.3
     optional: true
 
+  rxjs@7.8.2:
+    dependencies:
+      tslib: 2.8.1
+
   safe-buffer@5.2.1: {}
 
   safer-buffer@2.1.2: {}
@@ -2733,6 +2773,8 @@ snapshots:
       shebang-regex: 3.0.0
 
   shebang-regex@3.0.0: {}
+
+  shell-quote@1.8.3: {}
 
   signal-exit@3.0.7: {}
 
@@ -2813,6 +2855,10 @@ snapshots:
     dependencies:
       has-flag: 4.0.0
 
+  supports-color@8.1.1:
+    dependencies:
+      has-flag: 4.0.0
+
   tar@6.2.1:
     dependencies:
       chownr: 2.0.0
@@ -2842,6 +2888,8 @@ snapshots:
 
   tmp@0.2.3: {}
 
+  tree-kill@1.2.2: {}
+
   truncate-utf8-bytes@1.0.2:
     dependencies:
       utf8-byte-length: 1.0.5
@@ -2863,6 +2911,8 @@ snapshots:
       typescript: 5.8.3
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
+
+  tslib@2.8.1: {}
 
   type-fest@0.13.1:
     optional: true


### PR DESCRIPTION
- Changed API endpoint for updating invoice status from `/api/factures/:id/update` to `/api/factures/:id/status`.
- Ensured the request body is `{ status: newStatus }` with `newStatus` being 'paid' or 'unpaid'.
- Added toast notifications for success and error scenarios.
- Implemented dispatch of `factureStatutChange` event on successful update.