### PR TITLE
Fix invoice status update

### DIFF
--- a/frontend/src/pages/ListeFactures.test.tsx
+++ b/frontend/src/pages/ListeFactures.test.tsx
@@ -44,7 +44,7 @@ test('marque une facture comme payée', async () => {
 
   await waitFor(() =>
     expect(fetch as any).toHaveBeenCalledWith(
-      expect.stringContaining('/factures/1/update'),
+      expect.stringContaining('/factures/1/status'),
       expect.objectContaining({ method: 'PATCH' })
     )
   );

--- a/frontend/src/pages/ListeFactures.tsx
+++ b/frontend/src/pages/ListeFactures.tsx
@@ -172,7 +172,7 @@ export default function ListeFactures() {
 
   const marquerPayee = async (id: number) => {
     try {
-      const updated = await updateInvoiceStatus(id, 'payée');
+      const updated = await updateInvoiceStatus(id, 'paid');
       setFactures(prev => {
         const list = prev.map(f => (f.id === id ? updated : f));
         cacheInvoicesLocally(list);


### PR DESCRIPTION
## Summary
- send `'paid'` status when marking an invoice as paid
- update test to expect `/status` endpoint

## Testing
- `pnpm test` in `backend`
- `pnpm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_685b9b02aa44832fbf5f7ed8be8761ac