### PR TITLE
Add demo seed data and script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ backend/database/*.sqlite
 backend/uploads/*
 !backend/uploads/.gitkeep
 backend/last-facture.html
+backend/data/profil_utilisateur.json

--- a/README.md
+++ b/README.md
@@ -76,6 +76,18 @@ cd backend
 node database/migrations/002-add-legal-fields.js
 ```
 
+## 🎁 Données de démonstration
+Un jeu de données minimal est fourni dans `data/mockData`. Il permet de créer un
+profil utilisateur, un client et plusieurs factures pour tester l'application.
+
+```bash
+node backend/scripts/seed-demo-data.js
+```
+
+Le script n'insère les données que si la base est vide afin de ne pas écraser un
+travail existant. Il peut ainsi être lancé avant des tests manuels ou automatiqu
+es pour disposer d'exemples réalistes.
+
 ## 📁 Structure du projet
 ```
 Mam-s-Facture/

--- a/backend/package.json
+++ b/backend/package.json
@@ -8,7 +8,8 @@
     "start": "pnpm run build && API_TOKEN=test-token node dist/server.js",
     "dev": "nodemon --exec ts-node server.ts",
     "test": "NODE_ENV=test API_TOKEN=test-token jest",
-    "export-html": "node scripts/export-html.js"
+    "export-html": "node scripts/export-html.js",
+    "seed-demo": "node scripts/seed-demo-data.js"
   },
   "dependencies": {
     "body-parser": "^1.20.2",

--- a/backend/scripts/seed-demo-data.js
+++ b/backend/scripts/seed-demo-data.js
@@ -1,0 +1,68 @@
+const fs = require('fs');
+const path = require('path');
+const SQLiteDatabase = require('../database/sqlite');
+const { writeUserProfile } = require('../services/userProfileService');
+
+const DATA_DIR = path.join(__dirname, '..', '..', 'data', 'mockData');
+
+async function seed() {
+  const db = await SQLiteDatabase.create();
+
+  // Skip seeding if clients already exist
+  if (db.getClients().length > 0) {
+    console.log('Demo data already present. Skipping seeding.');
+    return;
+  }
+
+  const user = JSON.parse(fs.readFileSync(path.join(DATA_DIR, 'user.json'), 'utf-8'));
+  const clients = JSON.parse(fs.readFileSync(path.join(DATA_DIR, 'clients.json'), 'utf-8'));
+  const factures = JSON.parse(fs.readFileSync(path.join(DATA_DIR, 'factures.json'), 'utf-8'));
+
+  // Save user profile
+  await writeUserProfile({
+    raison_sociale: user.raison_sociale,
+    adresse: user.adresse,
+    code_postal: user.code_postal,
+    ville: user.ville,
+    forme_juridique: user.forme_juridique,
+    siret: user.siret,
+    ape_naf: user.ape_naf,
+    tva_intra: user.tva_intra,
+    rcs_ou_rm: user.rcs_ou_rm
+  });
+
+  const clientIdMap = {};
+  clients.forEach(c => {
+    const id = db.createClient(c);
+    clientIdMap[c.nom_entreprise] = id;
+  });
+
+  factures.forEach(f => {
+    const clientId = clientIdMap[f.clientKey];
+    db.createFacture({
+      client_id: clientId,
+      numero_facture: f.numero,
+      nom_client: clients[0].nom_client,
+      nom_entreprise: clients[0].nom_entreprise,
+      telephone: clients[0].telephone,
+      adresse: clients[0].adresse_facturation,
+      date_facture: f.date,
+      montant_total: f.montant,
+      status: f.status,
+      lignes: [
+        { description: f.description, quantite: 1, prix_unitaire: f.montant }
+      ]
+    });
+  });
+
+  console.log('Demo data inserted.');
+}
+
+if (require.main === module) {
+  seed().catch(err => {
+    console.error(err);
+    process.exit(1);
+  });
+}
+
+module.exports = seed;

--- a/data/mockData/clients.json
+++ b/data/mockData/clients.json
@@ -1,0 +1,13 @@
+[
+  {
+    "nom_client": "Diana Renoir",
+    "nom_entreprise": "Renoir Design",
+    "email": "diana@renoirdesign.com",
+    "telephone": "0690 00 00 00",
+    "adresse_facturation": "15 rue des Arts, 97100 Basse-Terre",
+    "adresse_livraison": "15 rue des Arts, 97100 Basse-Terre",
+    "siret": "11111111100011",
+    "legal_form": "SARL",
+    "rcs_number": "Basse-Terre 111 111 111"
+  }
+]

--- a/data/mockData/factures.json
+++ b/data/mockData/factures.json
@@ -1,0 +1,34 @@
+[
+  {
+    "clientKey": "Renoir Design",
+    "numero": "F001",
+    "status": "unpaid",
+    "description": "Site vitrine 3 pages",
+    "montant": 800,
+    "date": "2024-01-20"
+  },
+  {
+    "clientKey": "Renoir Design",
+    "numero": "F002",
+    "status": "paid",
+    "description": "Logo vectoriel",
+    "montant": 300,
+    "date": "2024-02-05"
+  },
+  {
+    "clientKey": "Renoir Design",
+    "numero": "F003",
+    "status": "unpaid",
+    "description": "Charte graphique",
+    "montant": 600,
+    "date": "2024-03-10"
+  },
+  {
+    "clientKey": "Renoir Design",
+    "numero": "F004",
+    "status": "paid",
+    "description": "Carte de visite imprimée",
+    "montant": 150,
+    "date": "2024-03-20"
+  }
+]

--- a/data/mockData/user.json
+++ b/data/mockData/user.json
@@ -1,0 +1,13 @@
+{
+  "raison_sociale": "Studio Mam’s Facture",
+  "nom_contact": "Alan Emmanuel-Emile",
+  "email": "alan@email.com",
+  "adresse": "1 rue de la Facture",
+  "code_postal": "97100",
+  "ville": "Basse-Terre",
+  "forme_juridique": "EI",
+  "siret": "99999999900016",
+  "ape_naf": "6201Z",
+  "tva_intra": "FR999999999",
+  "rcs_ou_rm": "Basse-Terre 999 999 999"
+}


### PR DESCRIPTION
## Summary
- provide `user`, `clients` and `factures` demo data in `data/mockData`
- add `seed-demo-data.js` to populate SQLite with this sample
- expose `pnpm seed-demo` script for backend
- document how to use demo data

## Testing
- `pnpm test` in `backend`
- `pnpm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_685b9d860530832f891932860c3ff0d3