### PR TITLE
Add MAMSFACTUREOPENER launcher

### DIFF
--- a/MAMSFACTUREOPENER
+++ b/MAMSFACTUREOPENER
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -e
+
+LOG_DIR="logs"
+LOG_FILE="$LOG_DIR/install.log"
+mkdir -p "$LOG_DIR"
+exec 2>>"$LOG_FILE"
+
+banner() {
+  cat <<'BANNER'
+ __  __                 _____           _                 
+|  \/  |               |  __ \         | |                
+| \  / | __ _ _ __ ___ | |__) |__   ___| |_ __ _ _ __ ___ 
+| |\/| |/ _` | '_ ` _ \|  ___/ _ \ / __| __/ _` | '__/ _ \
+| |  | | (_| | | | | | | |  | (_) | (__| || (_| | | |  __/
+|_|  |_|\__,_|_| |_| |_|_|   \___/ \___|\__\__,_|_|  \___|
+BANNER
+}
+
+banner
+
+if ! command -v pnpm >/dev/null 2>&1; then
+  echo "❌ pnpm n'est pas installé. Veuillez l'installer puis réessayer." >&2
+  exit 1
+fi
+
+echo "📦 Installation des dépendances backend..."
+pnpm install --filter backend...
+
+echo "📦 Installation des dépendances frontend..."
+pnpm install --filter frontend...
+
+echo "🔨 Compilation du backend..."
+pnpm --filter backend build
+
+echo "🚀 Lancement des serveurs..."
+pnpm dev:all &
+SERVERS_PID=$!
+
+sleep 3
+URL="http://localhost:5173"
+case "$(uname)" in
+  Darwin)
+    open "$URL" &
+    ;;
+  Linux)
+    xdg-open "$URL" &>/dev/null &
+    ;;
+  MINGW*|MSYS*|CYGWIN*)
+    start "$URL" &
+    ;;
+  *)
+    echo "Ouvrez votre navigateur sur $URL"
+    ;;
+esac
+
+echo "Application disponible sur $URL"
+
+trap "kill \$SERVERS_PID" SIGINT
+wait $SERVERS_PID


### PR DESCRIPTION
## Summary
- add a `MAMSFACTUREOPENER` shell script to install deps, build the backend and start both servers
- open the UI automatically with OS-specific command

## Testing
- `cd backend && pnpm install && pnpm test`
- `cd frontend && pnpm install && pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_685ba0381ad0832f9708973d7e6968b7