### PR TITLE
Apply sidebar spacing tweak for key pages

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -47,7 +47,8 @@ function AnimatedRoutes() {
   )
 }
 
-function App() {
+function Layout() {
+  const location = useLocation()
   const isMobile = useIsMobile()
   const [sidebarOpen, setSidebarOpen] = useState(!isMobile)
 
@@ -55,20 +56,29 @@ function App() {
     setSidebarOpen(!isMobile)
   }, [isMobile])
 
+  const smallMarginRoutes = ['/', '/factures', '/factures/nouvelle', '/clients', '/profile']
+  const useSmallMargin = smallMarginRoutes.some((path) => location.pathname.startsWith(path))
+
+  return (
+    <div className="flex h-screen overflow-hidden">
+      <Sidebar open={sidebarOpen} setOpen={setSidebarOpen} />
+      <div className="flex flex-col flex-1">
+        <TopBar onMenuClick={() => setSidebarOpen(true)} useSmallMargin={useSmallMargin} />
+        <main className={`flex-1 overflow-auto pt-16 px-4 py-6 ml-0 ${useSmallMargin ? 'md:ml-2' : 'md:ml-56'}`}>
+          <AnimatedRoutes />
+        </main>
+      </div>
+    </div>
+  )
+}
+
+function App() {
   return (
     <ErrorBoundary>
       <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
       <Router>
         <Toaster />
-        <div className="flex h-screen overflow-hidden">
-          <Sidebar open={sidebarOpen} setOpen={setSidebarOpen} />
-          <div className="flex flex-col flex-1">
-            <TopBar onMenuClick={() => setSidebarOpen(true)} />
-            <main className="flex-1 overflow-auto pt-16 px-4 py-6 pl-0 md:pl-56">
-              <AnimatedRoutes />
-            </main>
-          </div>
-        </div>
+        <Layout />
       </Router>
       </ThemeProvider>
     </ErrorBoundary>

--- a/frontend/src/components/TopBar.tsx
+++ b/frontend/src/components/TopBar.tsx
@@ -4,9 +4,10 @@ import { useIsMobile } from '../hooks/use-mobile'
 
 interface TopBarProps {
   onMenuClick: () => void
+  useSmallMargin?: boolean
 }
 
-export default function TopBar({ onMenuClick }: TopBarProps) {
+export default function TopBar({ onMenuClick, useSmallMargin }: TopBarProps) {
   const navigate = useNavigate()
   const location = useLocation()
   const isMobile = useIsMobile()
@@ -22,7 +23,7 @@ export default function TopBar({ onMenuClick }: TopBarProps) {
   const title = titles[location.pathname] || 'MAM\u2019s FACTURE'
 
   return (
-    <header className="fixed top-0 right-0 z-50 bg-slate-900 text-gray-50 shadow py-3 px-4 flex items-center justify-between md:left-56">
+    <header className={`fixed top-0 right-0 z-50 bg-slate-900 text-gray-50 shadow py-3 px-4 flex items-center justify-between left-0 ${useSmallMargin ? 'md:left-2' : 'md:left-56'}` }>
       {isMobile && (
         <button onClick={onMenuClick} className="mr-2 md:hidden">
           <Menu className="h-6 w-6" />


### PR DESCRIPTION
## Summary
- add Layout wrapper using `useSmallMargin` to reduce left margin on key pages
- pass margin flag to `TopBar` and adjust header offset

## Testing
- `cd backend && pnpm install && pnpm test`
- `cd frontend && pnpm install && pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_685ba4d861d0832f8ec36b7ccb58274c