### PR TITLE
Fix demo data loading and add seed test

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -4,7 +4,7 @@
   "description": "Application de facturation - Backend API",
   "main": "dist/server.js",
   "scripts": {
-    "build": "tsc && mkdir -p dist/services && cp services/htmlService.js dist/services/ && cp services/quoteService.js dist/services/ && cp services/userProfileService.js dist/services/ && ls -l dist/services && mkdir -p dist/database/data dist/database/migrations && cp database/sqlite.js dist/database/ && cp database/data/*.* dist/database/data/ && cp database/migrations/*.js dist/database/migrations/",
+    "build": "tsc && mkdir -p dist/services && cp services/htmlService.js dist/services/ && cp services/quoteService.js dist/services/ && cp services/userProfileService.js dist/services/ && ls -l dist/services && mkdir -p dist/database/data dist/database/migrations && cp database/sqlite.js dist/database/ && cp database/data/*.* dist/database/data/ && cp database/migrations/*.js dist/database/migrations/ && cp database/facturation.sqlite dist/database/",
     "start": "pnpm run build && API_TOKEN=test-token node dist/server.js",
     "dev": "nodemon --exec ts-node server.ts",
     "test": "NODE_ENV=test API_TOKEN=test-token jest",

--- a/backend/tests/demoData.test.js
+++ b/backend/tests/demoData.test.js
@@ -1,0 +1,26 @@
+const request = require('supertest');
+const seed = require('../scripts/seed-demo-data');
+let app;
+const API_TOKEN = 'test-token';
+
+beforeAll(async () => {
+  await seed();
+  app = await require('../server');
+});
+
+describe('Demo data seeding', () => {
+  test('returns seeded client and invoices', async () => {
+    const clientsRes = await request(app)
+      .get('/api/clients')
+      .set('Authorization', `Bearer ${API_TOKEN}`);
+    expect(clientsRes.status).toBe(200);
+    expect(clientsRes.body.length).toBeGreaterThanOrEqual(1);
+
+    const invoiceRes = await request(app)
+      .get('/api/factures')
+      .set('Authorization', `Bearer ${API_TOKEN}`);
+    expect(invoiceRes.status).toBe(200);
+    // Response shape { factures: [...], pagination: { ... } }
+    expect(invoiceRes.body.factures.length).toBeGreaterThanOrEqual(4);
+  });
+});


### PR DESCRIPTION
## Summary
- copy the SQLite database file during backend build so the app starts with seeded data
- test that seed-demo-data populates clients and invoices

## Testing
- `pnpm test` in `backend`
- `pnpm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_685c83ed69e0832fa2c3a524db1bd681