### PR TITLE
Ensure backend auth token in dev and reset DB for seeding tests

### DIFF
--- a/backend/tests/demoData.test.js
+++ b/backend/tests/demoData.test.js
@@ -3,7 +3,15 @@ const seed = require('../scripts/seed-demo-data');
 let app;
 const API_TOKEN = 'test-token';
 
+const fs = require('fs');
+const path = require('path');
+
 beforeAll(async () => {
+  // Reset the database to ensure consistent seeding
+  const dbPath = path.join(__dirname, '..', 'database', 'facturation.sqlite');
+  if (fs.existsSync(dbPath)) {
+    fs.unlinkSync(dbPath);
+  }
   await seed();
   app = await require('../server');
 });

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build:electron": "pnpm exec tsc -p electron/tsconfig.json",
     "build": "pnpm run build:web && pnpm run build:backend && pnpm run build:electron && electron-builder",
     "start": "pnpm run build:web && pnpm run build:backend && pnpm run build:electron && electron .",
-    "dev:all": "concurrently \"cd backend && pnpm dev\" \"cd frontend && pnpm dev\""
+    "dev:all": "concurrently \"cd backend && API_TOKEN=test-token pnpm dev\" \"cd frontend && pnpm dev\""
   },
   "dependencies": {
     "playwright": "^1.53.1"


### PR DESCRIPTION
## Summary
- set `API_TOKEN` when running `pnpm dev:all`
- clean SQLite database before seeding in `demoData` test to avoid flaky counts

## Testing
- `pnpm test` in `backend`
- `pnpm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_685c862a8a24832f9833cc4fd6779881