### PR TITLE
Update launcher scripts

### DIFF
--- a/MAMSFACTUREOPENER
+++ b/MAMSFACTUREOPENER
@@ -24,14 +24,20 @@ if ! command -v pnpm >/dev/null 2>&1; then
   exit 1
 fi
 
+echo "📦 Installation des dépendances racine..."
+pnpm install > /dev/null
+
 echo "📦 Installation des dépendances backend..."
-pnpm install --filter backend...
+pnpm --filter ./backend install > /dev/null
 
 echo "📦 Installation des dépendances frontend..."
-pnpm install --filter frontend...
+pnpm --filter ./frontend install > /dev/null
 
 echo "🔨 Compilation du backend..."
-pnpm --filter backend build
+pnpm --filter ./backend build > /dev/null
+
+echo "🔨 Construction du frontend..."
+pnpm --filter ./frontend run build > /dev/null
 
 echo "🚀 Lancement des serveurs..."
 pnpm dev:all &

--- a/launcher-safari
+++ b/launcher-safari
@@ -23,24 +23,29 @@ done
 cd "$(dirname "$0")"
 
 # Installe automatiquement les dépendances si nécessaire
-if ! command -v node >/dev/null 2>&1 \
-  || ! command -v pnpm >/dev/null 2>&1 \
-  || [ ! -d backend/node_modules ] || [ ! -d frontend/node_modules ]; then
-  echo "[launcher] Préparation de l'environnement (installation)..."
-  ./install_macos.sh --skip-build
-else
-  echo "[launcher] Vérification des mises à jour Homebrew..."
-  brew update >/dev/null
-  brew upgrade node pnpm >/dev/null || true
+if ! command -v node >/dev/null 2>&1 || ! command -v pnpm >/dev/null 2>&1; then
+  echo "[launcher] Node.js ou pnpm manquant, exécution de install_macos.sh..."
+  ./install_macos.sh
 fi
 
-# S'assure que les dépendances sont à jour
+# Gestionnaire de paquets : pnpm si disponible, sinon npm
 PM=pnpm
 if ! command -v pnpm >/dev/null 2>&1; then
   PM=npm
 fi
+
+# Installation des dépendances (racine, backend puis frontend)
+echo "[launcher] Installation des dépendances racine..."
+"$PM" install > /dev/null
+
+echo "[launcher] Installation des dépendances backend..."
 (cd backend && "$PM" install > /dev/null)
+
+echo "[launcher] Installation des dépendances frontend..."
 (cd frontend && "$PM" install > /dev/null)
+
+echo "[launcher] Construction du frontend..."
+(cd frontend && "$PM" run build > /dev/null)
 
 echo "[launcher] Démarrage du backend..."
 (cd backend && "$PM" start > ../backend.log 2>&1 &)


### PR DESCRIPTION
## Summary
- rename `launch_safari.sh` to `launcher-safari` and extend it to install deps, build the frontend, start both servers and open Safari
- fix `MAMSFACTUREOPENER` to install root dependencies and build before running `dev:all`

## Testing
- `cd backend && pnpm test`
- `cd frontend && pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_685c8daafd40832f8353e768e4688009