### PR TITLE
Update macOS launch scripts

### DIFF
--- a/MAMSFACTUREOPENER
+++ b/MAMSFACTUREOPENER
@@ -1,66 +1,45 @@
 #!/usr/bin/env bash
-set -e
+set -euo pipefail
 
-LOG_DIR="logs"
-LOG_FILE="$LOG_DIR/install.log"
-mkdir -p "$LOG_DIR"
-exec 2>>"$LOG_FILE"
-
-banner() {
-  cat <<'BANNER'
- __  __                 _____           _                 
-|  \/  |               |  __ \         | |                
-| \  / | __ _ _ __ ___ | |__) |__   ___| |_ __ _ _ __ ___ 
-| |\/| |/ _` | '_ ` _ \|  ___/ _ \ / __| __/ _` | '__/ _ \
-| |  | | (_| | | | | | | |  | (_) | (__| || (_| | | |  __/
-|_|  |_|\__,_|_| |_| |_|_|   \___/ \___|\__\__,_|_|  \___|
-BANNER
-}
-
-banner
-
-if ! command -v pnpm >/dev/null 2>&1; then
-  echo "❌ pnpm n'est pas installé. Veuillez l'installer puis réessayer." >&2
+if [[ "$(uname)" != "Darwin" ]]; then
+  echo "Ce script est destiné à macOS." >&2
   exit 1
 fi
 
-echo "📦 Installation des dépendances racine..."
-pnpm install > /dev/null
+error_exit() {
+  echo "❌ $1" >&2
+  exit 1
+}
 
-echo "📦 Installation des dépendances backend..."
-pnpm --filter ./backend install > /dev/null
+echo "🔧 [1/5] Installation des dépendances..."
+pnpm install --frozen-lockfile || error_exit "Impossible d'installer les dépendances racine."
+(cd backend && pnpm install --frozen-lockfile) || error_exit "Impossible d'installer les dépendances backend."
+(cd frontend && pnpm install --frozen-lockfile && pnpm build) || error_exit "Échec de la compilation du frontend."
 
-echo "📦 Installation des dépendances frontend..."
-pnpm --filter ./frontend install > /dev/null
+echo "✅ [2/5] Frontend compilé avec succès"
 
-echo "🔨 Compilation du backend..."
-pnpm --filter ./backend build > /dev/null
-
-echo "🔨 Construction du frontend..."
-pnpm --filter ./frontend run build > /dev/null
-
-echo "🚀 Lancement des serveurs..."
+echo "🚀 [3/5] Lancement des serveurs..."
 pnpm dev:all &
 SERVERS_PID=$!
 
-sleep 3
-URL="http://localhost:5173"
-case "$(uname)" in
-  Darwin)
-    open "$URL" &
-    ;;
-  Linux)
-    xdg-open "$URL" &>/dev/null &
-    ;;
-  MINGW*|MSYS*|CYGWIN*)
-    start "$URL" &
-    ;;
-  *)
-    echo "Ouvrez votre navigateur sur $URL"
-    ;;
-esac
+# Attente que le port 5173 soit disponible
+for i in {1..15}; do
+  if nc -z localhost 5173 2>/dev/null; then
+    READY=1
+    break
+  fi
+  sleep 1
+done
 
-echo "Application disponible sur $URL"
+if [[ -z ${READY:-} ]]; then
+  kill "$SERVERS_PID"
+  error_exit "Le port 5173 n'est pas disponible."
+fi
 
-trap "kill \$SERVERS_PID" SIGINT
-wait $SERVERS_PID
+echo "🌐 [4/5] Ouverture de Safari..."
+open -a Safari http://localhost:5173 || { kill "$SERVERS_PID"; error_exit "Impossible d'ouvrir Safari."; }
+
+echo "🎉 [5/5] L'application est lancée !"
+
+trap "kill \"$SERVERS_PID\"" SIGINT
+wait "$SERVERS_PID"

--- a/launcher-safari
+++ b/launcher-safari
@@ -1,68 +1,45 @@
 #!/usr/bin/env bash
-set -e
-
-# ---------------------------------------------------------------
-# Lanceur rapide pour macOS
-# Permet de spécifier le navigateur via --browser=NAME ou de ne pas en ouvrir
-# ---------------------------------------------------------------
+set -euo pipefail
 
 if [[ "$(uname)" != "Darwin" ]]; then
   echo "Ce script est destiné à macOS." >&2
   exit 1
 fi
 
-BROWSER="Safari"
-NO_BROWSER=0
-for arg in "$@"; do
-  case $arg in
-    --browser=*) BROWSER="${arg#*=}" ;;
-    --no-browser) NO_BROWSER=1 ;;
-  esac
+error_exit() {
+  echo "❌ $1" >&2
+  exit 1
+}
+
+echo "🔧 [1/5] Installation des dépendances..."
+pnpm install --frozen-lockfile || error_exit "Impossible d'installer les dépendances racine."
+(cd backend && pnpm install --frozen-lockfile) || error_exit "Impossible d'installer les dépendances backend."
+(cd frontend && pnpm install --frozen-lockfile && pnpm build) || error_exit "Échec de la compilation du frontend."
+
+echo "✅ [2/5] Frontend compilé avec succès"
+
+echo "🚀 [3/5] Lancement des serveurs..."
+pnpm dev:all &
+SERVERS_PID=$!
+
+# Attente que le port 5173 soit disponible
+for i in {1..15}; do
+  if nc -z localhost 5173 2>/dev/null; then
+    READY=1
+    break
+  fi
+  sleep 1
 done
 
-cd "$(dirname "$0")"
-
-# Installe automatiquement les dépendances si nécessaire
-if ! command -v node >/dev/null 2>&1 || ! command -v pnpm >/dev/null 2>&1; then
-  echo "[launcher] Node.js ou pnpm manquant, exécution de install_macos.sh..."
-  ./install_macos.sh
+if [[ -z ${READY:-} ]]; then
+  kill "$SERVERS_PID"
+  error_exit "Le port 5173 n'est pas disponible."
 fi
 
-# Gestionnaire de paquets : pnpm si disponible, sinon npm
-PM=pnpm
-if ! command -v pnpm >/dev/null 2>&1; then
-  PM=npm
-fi
+echo "🌐 [4/5] Ouverture de Safari..."
+open -a Safari http://localhost:5173 || { kill "$SERVERS_PID"; error_exit "Impossible d'ouvrir Safari."; }
 
-# Installation des dépendances (racine, backend puis frontend)
-echo "[launcher] Installation des dépendances racine..."
-"$PM" install > /dev/null
+echo "🎉 [5/5] L'application est lancée !"
 
-echo "[launcher] Installation des dépendances backend..."
-(cd backend && "$PM" install > /dev/null)
-
-echo "[launcher] Installation des dépendances frontend..."
-(cd frontend && "$PM" install > /dev/null)
-
-echo "[launcher] Construction du frontend..."
-(cd frontend && "$PM" run build > /dev/null)
-
-echo "[launcher] Démarrage du backend..."
-(cd backend && "$PM" start > ../backend.log 2>&1 &)
-BACK_PID=$!
-
-echo "[launcher] Démarrage du frontend..."
-(cd frontend && "$PM" run dev > ../frontend.log 2>&1 &)
-FRONT_PID=$!
-
-sleep 3
-URL="http://localhost:5173"
-if [ "$NO_BROWSER" -eq 0 ]; then
-  open -a "$BROWSER" "$URL"
-  echo "[launcher] $BROWSER ouvert sur $URL"
-else
-  echo "[launcher] Application disponible sur $URL"
-fi
-
-trap "kill $BACK_PID $FRONT_PID" SIGINT
-wait $FRONT_PID
+trap "kill \"$SERVERS_PID\"" SIGINT
+wait "$SERVERS_PID"


### PR DESCRIPTION
## Summary
- simplify `launcher-safari`
- simplify `MAMSFACTUREOPENER`
- run installation, build and dev workflow with helpful messages
- check for port 5173 before launching browser

## Testing
- `cd backend && pnpm install && pnpm test`
- `cd frontend && pnpm install && pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_685c8f7d7250832f9e2595444afec28d