### PR TITLE
Improve launcher-safari portability

### DIFF
--- a/launcher-safari
+++ b/launcher-safari
@@ -1,6 +1,13 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Se place dans la racine du projet quel que soit l'endroit d'où le script est lancé
+cd "$(dirname "$0")/.." || exit 1
+if [[ ! -d backend ]]; then
+  # Le script était déjà a la racine
+  cd "$(dirname "$0")" || exit 1
+fi
+
 if [[ "$(uname)" != "Darwin" ]]; then
   echo "Ce script est destiné à macOS." >&2
   exit 1


### PR DESCRIPTION
## Summary
- move to the repository root before launching the servers
- handle running the script from subfolders

## Testing
- `cd backend && pnpm install && pnpm test`
- `cd frontend && pnpm install && pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_685c9384d360832f9229975e83efe771