### PR TITLE
Fix demo data seeding during tests

### DIFF
--- a/backend/scripts/seed-demo-data.js
+++ b/backend/scripts/seed-demo-data.js
@@ -6,6 +6,14 @@ const { writeUserProfile } = require('../services/userProfileService');
 const DATA_DIR = path.join(__dirname, '..', '..', 'data', 'mockData');
 
 async function seed() {
+  // If the server module was loaded previously (e.g. in other tests), remove it
+  // from the require cache so requiring it again returns a fresh instance with
+  // a newly created database.
+  const serverPath = path.join(__dirname, '..', 'server');
+  if (require.cache[require.resolve(serverPath)]) {
+    delete require.cache[require.resolve(serverPath)];
+  }
+
   const db = await SQLiteDatabase.create();
 
   // Skip seeding if clients already exist


### PR DESCRIPTION
## Summary
- ensure the test seed script invalidates the cached server module

## Testing
- `cd backend && pnpm test`
- `cd frontend && pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_685c9615c778832fb84738e05e994fb4