### PR TITLE
Update launcher-safari to kill existing server ports

### DIFF
--- a/launcher-safari
+++ b/launcher-safari
@@ -18,6 +18,21 @@ error_exit() {
   exit 1
 }
 
+echo "🧹 [0/5] Libération des ports si nécessaires..."
+PORTS_TO_FREE=(3001 5173)
+
+for PORT in "${PORTS_TO_FREE[@]}"; do
+  PID=$(lsof -ti tcp:$PORT)
+  if [ -n "$PID" ]; then
+    echo "⚠️ Port $PORT utilisé par le process $PID, on le tue..."
+    kill -9 $PID || echo "❌ Impossible de tuer le process $PID sur le port $PORT"
+  else
+    echo "✅ Port $PORT déjà libre"
+  fi
+done
+
+echo "🟢 Tous les ports critiques sont prêts."
+
 echo "🔧 [1/5] Installation des dépendances..."
 pnpm install --frozen-lockfile || error_exit "Impossible d'installer les dépendances racine."
 (cd backend && pnpm install --frozen-lockfile) || error_exit "Impossible d'installer les dépendances backend."


### PR DESCRIPTION
## Summary
- free ports 3001 and 5173 before running the macOS launcher

## Testing
- `cd backend && pnpm install && pnpm test`
- `cd frontend && pnpm install && pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_685c9d15b600832fa5b9d9248e22bc99