### PR TITLE
Seed demo data only on first launch

### DIFF
--- a/backend/database/sqlite.js
+++ b/backend/database/sqlite.js
@@ -22,6 +22,10 @@ class SQLiteDatabase {
   }
 
   init() {
+    this.db.run(`CREATE TABLE IF NOT EXISTS meta (
+      key TEXT PRIMARY KEY,
+      value TEXT
+    );`);
     this.db.run(`CREATE TABLE IF NOT EXISTS clients (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
       nom_client TEXT NOT NULL,
@@ -484,6 +488,23 @@ class SQLiteDatabase {
     stmt.free();
     this.save();
     return this.getUserProfile(); // Return the updated profile
+  }
+
+  getMeta(key) {
+    const stmt = this.db.prepare('SELECT value FROM meta WHERE key=?');
+    stmt.bind([key]);
+    const value = stmt.step() ? stmt.getAsObject().value : null;
+    stmt.free();
+    return value;
+  }
+
+  setMeta(key, value) {
+    const stmt = this.db.prepare(
+      'INSERT INTO meta (key, value) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value=excluded.value'
+    );
+    stmt.run([key, value]);
+    stmt.free();
+    this.save();
   }
 }
 

--- a/backend/scripts/seed-demo-data.js
+++ b/backend/scripts/seed-demo-data.js
@@ -5,7 +5,7 @@ const { writeUserProfile } = require('../services/userProfileService');
 
 const DATA_DIR = path.join(__dirname, '..', '..', 'data', 'mockData');
 
-async function seed() {
+async function seed(dbInstance) {
   // If the server module was loaded previously (e.g. in other tests), remove it
   // from the require cache so requiring it again returns a fresh instance with
   // a newly created database.
@@ -14,7 +14,7 @@ async function seed() {
     delete require.cache[require.resolve(serverPath)];
   }
 
-  const db = await SQLiteDatabase.create();
+  const db = dbInstance || await SQLiteDatabase.create();
 
   // Skip seeding if clients already exist
   if (db.getClients().length > 0) {
@@ -64,6 +64,10 @@ async function seed() {
   });
 
   console.log('Demo data inserted.');
+
+  if (typeof db.setMeta === 'function') {
+    db.setMeta('hasSeeded', 'true');
+  }
 }
 
 if (require.main === module) {


### PR DESCRIPTION
## Summary
- introduce a `meta` table in SQLite for config flags
- add `getMeta` and `setMeta` helpers
- update demo seeding script to accept a db instance and set a `hasSeeded` flag
- load demo data on first server start via `seedIfNeeded`
- mark database seeded whenever user data changes

## Testing
- `cd backend && pnpm install && pnpm test`
- `cd ../frontend && pnpm install && pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_685c9ea431c8832fa123d985bc5a5c63