### PR TITLE
Add seedIfNeeded verification test

### DIFF
--- a/backend/tests/seedIfNeeded.test.js
+++ b/backend/tests/seedIfNeeded.test.js
@@ -1,0 +1,49 @@
+const fs = require('fs');
+const path = require('path');
+const SQLiteDatabase = require('../database/sqlite');
+const { readUserProfile } = require('../services/userProfileService');
+
+const dbPath = path.join(__dirname, '..', 'database', 'facturation.sqlite');
+const profilePath = path.join(__dirname, '..', 'data', 'profil_utilisateur.json');
+
+let app;
+
+const waitForSeed = async () => {
+  for (let i = 0; i < 20; i++) {
+    if (fs.existsSync(dbPath)) {
+      const db = await SQLiteDatabase.create();
+      if (db.getMeta('hasSeeded')) return;
+    }
+    await new Promise(res => setTimeout(res, 100));
+  }
+};
+
+describe('seedIfNeeded() on server startup', () => {
+  beforeAll(async () => {
+    if (fs.existsSync(dbPath)) fs.unlinkSync(dbPath);
+    if (fs.existsSync(profilePath)) fs.unlinkSync(profilePath);
+    jest.resetModules();
+    app = await require('../server');
+    await waitForSeed();
+  });
+
+  test('inserts demo data and sets hasSeeded', async () => {
+    const db = await SQLiteDatabase.create();
+    const hasSeeded = db.getMeta('hasSeeded');
+    expect(hasSeeded).toBe('true');
+    expect(db.getClients().length).toBeGreaterThanOrEqual(1);
+    const profile = await readUserProfile();
+    expect(profile).not.toBeNull();
+  });
+
+  test('does not reseed when restarted', async () => {
+    const db1 = await SQLiteDatabase.create();
+    const clientCount = db1.getClients().length;
+    jest.resetModules();
+    app = await require('../server');
+    await waitForSeed();
+    const db2 = await SQLiteDatabase.create();
+    expect(db2.getMeta('hasSeeded')).toBe('true');
+    expect(db2.getClients().length).toBe(clientCount);
+  });
+});


### PR DESCRIPTION
## Summary
- add regression test ensuring `seedIfNeeded` populates demo data only once

## Testing
- `cd backend && pnpm install && pnpm test`
- `cd frontend && pnpm install && pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_685ca43c9544832f9c6a0b6f0e86fbd4