### PR TITLE
Improve initial demo data loading

### DIFF
--- a/frontend/.env
+++ b/frontend/.env
@@ -1,1 +1,3 @@
 VITE_API_URL=http://localhost:3001/api
+
+VITE_API_TOKEN=test-token

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -75,13 +75,23 @@ interface ProfileDataForUpdate {
 }
 
 
+const DEFAULT_TOKEN =
+  (typeof process !== 'undefined' && process.env?.VITE_API_TOKEN) ||
+  import.meta.env?.VITE_API_TOKEN ||
+  'test-token';
+
 const getAuthToken = () => {
-  // In a real app, you'd get this from localStorage, Redux store, context, etc.
-  // For this example, let's assume it's stored in localStorage or is a known static value.
-  // This matches the simple token check in backend/server.js (process.env.API_TOKEN)
-  // Replace 'your_static_api_token' with the actual token if it's static,
-  // or implement proper token retrieval.
-  return localStorage.getItem('apiToken') || '';
+  // Retrieve the token from localStorage.  If it's not set (first launch),
+  // initialise it with the default demo token so API requests succeed.
+  if (typeof window !== 'undefined') {
+    let token = localStorage.getItem('apiToken');
+    if (!token) {
+      localStorage.setItem('apiToken', DEFAULT_TOKEN);
+      token = DEFAULT_TOKEN;
+    }
+    return token;
+  }
+  return DEFAULT_TOKEN;
 };
 
 export const apiClient = {

--- a/frontend/src/pages/Clients.tsx
+++ b/frontend/src/pages/Clients.tsx
@@ -93,8 +93,12 @@ export default function Clients() {
 
 
   const chargerClients = async () => {
-    const data = await apiClient.getClients();
-    setClients(data);
+    try {
+      const data = await apiClient.getClients();
+      setClients(data);
+    } catch (err) {
+      console.error('Erreur chargement clients:', err);
+    }
   }
 
   useEffect(() => {
@@ -355,6 +359,11 @@ export default function Clients() {
             </form>
           )}
         </Card>
+        {clients.length === 0 && (
+          <div className="col-span-full text-center text-gray-500">
+            Aucun client trouvé
+          </div>
+        )}
         {clients.map((c) => (
           editingId === c.id ? (
             <Card key={c.id}>


### PR DESCRIPTION
## Summary
- auto-configure API token on first launch
- handle errors when loading clients
- show a message when no clients are available

## Testing
- `pnpm install && pnpm test` in `backend/` *(fails: seedIfNeeded and demoData tests)*
- `pnpm install && pnpm test` in `frontend/`

------
https://chatgpt.com/codex/tasks/task_e_685ca6223480832fa83895ca3c085bad