### PR TITLE
Fix demo data loading in UI

### DIFF
--- a/frontend/src/pages/AfficherProfilUtilisateur.tsx
+++ b/frontend/src/pages/AfficherProfilUtilisateur.tsx
@@ -9,27 +9,30 @@ import { ArrowLeft, Edit3 } from 'lucide-react';
 const AfficherProfilUtilisateur: React.FC = () => {
   const [profile, setProfile] = useState<UserProfileJson | null>(null);
   const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
   const navigate = useNavigate();
   const { toast } = useToast();
 
   useEffect(() => {
     const fetchProfileData = async () => {
       setIsLoading(true);
+      setError(null);
       try {
         const data = await apiClient.getUserProfile(); // Fetches the JSON structure
+        console.log('Profil récupéré:', data);
         if (data) {
           setProfile(data);
         } else {
-          // This case should ideally be handled by the 404 catch block
           toast({
             title: 'Profil non trouvé',
             description: 'Aucun profil utilisateur configuré. Veuillez compléter vos informations.',
             variant: 'default',
           });
-          navigate('/profile');
+          setProfile(null);
         }
       } catch (error: any) {
         console.error('Failed to fetch profile for display:', error);
+        setError('Impossible de charger les informations du profil.');
         if (error.message && error.message.includes('404')) {
            toast({
             title: 'Profil non trouvé',
@@ -43,25 +46,27 @@ const AfficherProfilUtilisateur: React.FC = () => {
                 variant: 'destructive',
             });
         }
-        navigate('/profile'); // Redirect to edit page if profile doesn't exist or error
       } finally {
         setIsLoading(false);
       }
     };
 
     fetchProfileData();
-  }, [navigate, toast]);
+  }, [toast]);
 
   if (isLoading) {
     return <div className="container mx-auto p-4 text-center">Chargement du profil...</div>;
   }
 
+  if (error) {
+    return <div className="container mx-auto p-4 text-center text-red-600">{error}</div>;
+  }
+
   if (!profile) {
-    // This is a fallback, useEffect should already redirect
     return (
-        <div className="container mx-auto p-4 text-center">
-            <p>Profil non trouvé. Vous allez être redirigé...</p>
-        </div>
+      <div className="container mx-auto p-4 text-center">
+        <p>Aucune information utilisateur trouvée.</p>
+      </div>
     );
   }
 

--- a/frontend/src/pages/Clients.tsx
+++ b/frontend/src/pages/Clients.tsx
@@ -39,6 +39,8 @@ interface Client {
 
 export default function Clients() {
   const [clients, setClients] = useState<Client[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
   const navigate = useNavigate()
   // New client form state
   const [nom, setNom] = useState('') // Nom / Raison sociale (uses nom_client for individual, entreprise for company)
@@ -93,11 +95,17 @@ export default function Clients() {
 
 
   const chargerClients = async () => {
+    setIsLoading(true)
+    setError(null)
     try {
       const data = await apiClient.getClients();
+      console.log('Clients récupérés:', data)
       setClients(data);
-    } catch (err) {
+    } catch (err: any) {
       console.error('Erreur chargement clients:', err);
+      setError('Erreur lors du chargement des clients.');
+    } finally {
+      setIsLoading(false);
     }
   }
 
@@ -222,6 +230,14 @@ export default function Clients() {
         variant: 'destructive',
       });
     }
+  }
+
+  if (isLoading) {
+    return <div className="p-6 text-center">Chargement des clients...</div>
+  }
+
+  if (error) {
+    return <div className="p-6 text-center text-red-600">{error}</div>
   }
 
   return (


### PR DESCRIPTION
## Summary
- handle loading and error states when displaying the user profile
- show client loading/error states and log loaded demo data

## Testing
- `pnpm test` in `frontend`
- `pnpm test` in `backend`

------
https://chatgpt.com/codex/tasks/task_e_685ca94919e4832f86c9ed6a01b101f1