### PR TITLE
Fix demo user seeding and profile page defaults

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -7,7 +7,7 @@
     "build": "tsc && mkdir -p dist/services && cp services/htmlService.js dist/services/ && cp services/quoteService.js dist/services/ && cp services/userProfileService.js dist/services/ && ls -l dist/services && mkdir -p dist/database/data dist/database/migrations && cp database/sqlite.js dist/database/ && cp database/data/*.* dist/database/data/ && cp database/migrations/*.js dist/database/migrations/ && cp database/facturation.sqlite dist/database/",
     "start": "pnpm run build && API_TOKEN=test-token node dist/server.js",
     "dev": "nodemon --exec ts-node server.ts",
-    "test": "NODE_ENV=test API_TOKEN=test-token jest",
+    "test": "NODE_ENV=test API_TOKEN=test-token jest --runInBand",
     "export-html": "node scripts/export-html.js",
     "seed-demo": "node scripts/seed-demo-data.js"
   },

--- a/backend/scripts/seed-demo-data.js
+++ b/backend/scripts/seed-demo-data.js
@@ -36,7 +36,11 @@ async function seed(dbInstance) {
     siret: user.siret,
     ape_naf: user.ape_naf,
     tva_intra: user.tva_intra,
-    rcs_ou_rm: user.rcs_ou_rm
+    rcs_ou_rm: user.rcs_ou_rm,
+    email: user.email,
+    phone: user.phone,
+    social_capital: user.social_capital,
+    activity_start_date: user.activity_start_date
   });
 
   const clientIdMap = {};

--- a/backend/services/userProfileService.js
+++ b/backend/services/userProfileService.js
@@ -74,7 +74,11 @@ const writeUserProfile = async (profileData) => {
     siret: String(profileData.siret || '').trim(),
     ape_naf: String(profileData.ape_naf || '').trim(),
     tva_intra: String(profileData.tva_intra || '').trim(),
-    rcs_ou_rm: String(profileData.rcs_ou_rm || '').trim()
+    rcs_ou_rm: String(profileData.rcs_ou_rm || '').trim(),
+    email: String(profileData.email || '').trim(),
+    phone: String(profileData.phone || '').trim(),
+    social_capital: String(profileData.social_capital || '').trim(),
+    activity_start_date: String(profileData.activity_start_date || '').trim()
   };
 
   try {

--- a/data/mockData/user.json
+++ b/data/mockData/user.json
@@ -9,5 +9,8 @@
   "siret": "99999999900016",
   "ape_naf": "6201Z",
   "tva_intra": "FR999999999",
-  "rcs_ou_rm": "Basse-Terre 999 999 999"
+  "rcs_ou_rm": "Basse-Terre 999 999 999",
+  "phone": "0102030405",
+  "social_capital": "1000",
+  "activity_start_date": "2020-01-01"
 }

--- a/frontend/src/pages/AfficherProfilUtilisateur.tsx
+++ b/frontend/src/pages/AfficherProfilUtilisateur.tsx
@@ -21,7 +21,33 @@ const AfficherProfilUtilisateur: React.FC = () => {
         const data = await apiClient.getUserProfile(); // Fetches the JSON structure
         console.log('Profil récupéré:', data);
         if (data) {
-          setProfile(data);
+          const expected = [
+            'raison_sociale',
+            'adresse',
+            'code_postal',
+            'ville',
+            'forme_juridique',
+            'siret',
+            'ape_naf',
+            'tva_intra',
+            'rcs_ou_rm',
+            'email',
+            'phone',
+            'social_capital',
+            'activity_start_date'
+          ] as const;
+          expected.forEach(field => {
+            if (!data[field]) {
+              console.warn(`Champ manquant dans le profil utilisateur: ${field}`);
+            }
+          });
+          setProfile({
+            ...data,
+            email: data.email || 'demo@example.com',
+            phone: data.phone || '0000000000',
+            social_capital: data.social_capital || '0',
+            activity_start_date: data.activity_start_date || '1970-01-01'
+          });
         } else {
           toast({
             title: 'Profil non trouvé',

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -59,6 +59,26 @@ export default function ProfilePage() {
       try {
         const dataFromApi = await apiClient.getUserProfile(); // This now fetches JSON structure
         if (dataFromApi) {
+          const expected = [
+            'raison_sociale',
+            'adresse',
+            'code_postal',
+            'ville',
+            'forme_juridique',
+            'siret',
+            'ape_naf',
+            'tva_intra',
+            'rcs_ou_rm',
+            'email',
+            'phone',
+            'social_capital',
+            'activity_start_date'
+          ] as const;
+          expected.forEach(field => {
+            if (!dataFromApi[field]) {
+              console.warn(`Champ manquant dans le profil utilisateur: ${field}`);
+            }
+          });
           // Map incoming JSON structure to form fields
           const formCompatibleData: FormProfileData = {
             full_name: dataFromApi.raison_sociale || '',
@@ -74,10 +94,10 @@ export default function ProfilePage() {
             // This part might need adjustment based on whether these fields are still stored anywhere else
             // or if they should be removed from the form if not part of the new spec.
             // For now, we assume they might come from an older profile or should be empty.
-            email: dataFromApi.email || '',
-            phone: dataFromApi.phone || '',
-            activity_start_date: dataFromApi.activity_start_date || '',
-            social_capital: dataFromApi.social_capital || '',
+            email: dataFromApi.email || 'demo@example.com',
+            phone: dataFromApi.phone || '0000000000',
+            activity_start_date: dataFromApi.activity_start_date || '1970-01-01',
+            social_capital: dataFromApi.social_capital || '0',
           };
           setProfile(formCompatibleData);
         }


### PR DESCRIPTION
## Summary
- seed demo user with email, phone, capital and activity start date
- persist optional fields in user profile service
- warn when profile fields are missing in display or edit pages
- provide demo fallbacks for missing profile fields in the UI
- run backend tests sequentially for stability

## Testing
- `cd backend && pnpm install && pnpm test`
- `cd frontend && pnpm install && pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_685cac84d058832fad713fa40dd57457