### PR TITLE
Improve backend launch reliability

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "tsc && mkdir -p dist/services && cp services/htmlService.js dist/services/ && cp services/quoteService.js dist/services/ && cp services/userProfileService.js dist/services/ && ls -l dist/services && mkdir -p dist/database/data dist/database/migrations && cp database/sqlite.js dist/database/ && cp database/data/*.* dist/database/data/ && cp database/migrations/*.js dist/database/migrations/ && cp database/facturation.sqlite dist/database/",
     "start": "pnpm run build && API_TOKEN=test-token node dist/server.js",
-    "dev": "nodemon --exec ts-node server.ts",
+    "dev": "nodemon --cwd ./ --watch src --exec \"ts-node server.ts\"",
     "test": "NODE_ENV=test API_TOKEN=test-token jest --runInBand",
     "export-html": "node scripts/export-html.js",
     "seed-demo": "node scripts/seed-demo-data.js"

--- a/launcher-safari
+++ b/launcher-safari
@@ -52,6 +52,16 @@ pnpm install --frozen-lockfile || error_exit "Impossible d'installer les dépend
 
 echo "✅ [2/5] Frontend compilé avec succès"
 
+# Vérification des permissions d'écriture dans backend
+cd "$(dirname "$0")/backend"
+echo test > .perm-test || PERM_ERROR=1
+rm -f .perm-test
+if [[ ${PERM_ERROR:-} ]]; then
+  echo "❌ Permissions insuffisantes dans /backend. Essayez : sudo chown -R $USER ./backend" >&2
+  exit 1
+fi
+cd "$(dirname "$0")"
+
 echo "🚀 [3/5] Lancement des serveurs..."
 pnpm dev:all &
 SERVERS_PID=$!
@@ -76,4 +86,4 @@ open -a Safari http://localhost:5173 || { kill "$SERVERS_PID"; error_exit "Impos
 echo "🎉 [5/5] L'application est lancée !"
 
 trap "kill \"$SERVERS_PID\"" SIGINT
-wait "$SERVERS_PID"
+wait "$SERVERS_PID" || echo "⚠️  Backend crashed — vérifiez les permissions ou le port 3001" >&2

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build:electron": "pnpm exec tsc -p electron/tsconfig.json",
     "build": "pnpm run build:web && pnpm run build:backend && pnpm run build:electron && electron-builder",
     "start": "pnpm run build:web && pnpm run build:backend && pnpm run build:electron && electron .",
-    "dev:all": "concurrently \"cd backend && API_TOKEN=test-token pnpm dev\" \"cd frontend && pnpm dev\""
+    "dev:all": "concurrently \"cd backend && API_TOKEN=test-token pnpm dev\" \"cd frontend && pnpm dev\"",
+    "test:backend:launch": "bash scripts/test-backend-launch.sh"
   },
   "dependencies": {
     "playwright": "^1.53.1"

--- a/scripts/test-backend-launch.sh
+++ b/scripts/test-backend-launch.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+pnpm --filter backend dev &
+PID=$!
+
+for i in {1..10}; do
+  RESP=$(curl -s http://localhost:3001/health || true)
+  if [[ "$RESP" == '{"ok":true}' ]]; then
+    SUCCESS=1
+    break
+  fi
+  sleep 1
+done
+
+kill $PID || true
+
+if [[ -n ${SUCCESS:-} ]]; then
+  echo "Backend launch test succeeded"
+  exit 0
+else
+  echo "Backend launch test failed"
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- add permission pre-check in `launcher-safari`
- warn if backend crashes
- run nodemon from backend directory
- provide script to test backend launch

## Testing
- `cd backend && pnpm install && pnpm test`
- `cd frontend && pnpm install && pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_685cb0d36a50832f8cda3e236ae2d739