### PR TITLE
Persist profile info

### DIFF
--- a/backend/scripts/seed-demo-data.js
+++ b/backend/scripts/seed-demo-data.js
@@ -1,7 +1,6 @@
 const fs = require('fs');
 const path = require('path');
 const SQLiteDatabase = require('../database/sqlite');
-const { writeUserProfile } = require('../services/userProfileService');
 
 const DATA_DIR = path.join(__dirname, '..', '..', 'data', 'mockData');
 
@@ -26,17 +25,17 @@ async function seed(dbInstance) {
   const clients = JSON.parse(fs.readFileSync(path.join(DATA_DIR, 'clients.json'), 'utf-8'));
   const factures = JSON.parse(fs.readFileSync(path.join(DATA_DIR, 'factures.json'), 'utf-8'));
 
-  // Save user profile
-  await writeUserProfile({
-    raison_sociale: user.raison_sociale,
-    adresse: user.adresse,
-    code_postal: user.code_postal,
-    ville: user.ville,
-    forme_juridique: user.forme_juridique,
-    siret: user.siret,
-    ape_naf: user.ape_naf,
-    tva_intra: user.tva_intra,
-    rcs_ou_rm: user.rcs_ou_rm,
+  // Save user profile in SQLite
+  db.upsertUserProfile({
+    full_name: user.raison_sociale,
+    address_street: user.adresse,
+    address_postal_code: user.code_postal,
+    address_city: user.ville,
+    legal_form: user.forme_juridique,
+    siret_siren: user.siret,
+    ape_naf_code: user.ape_naf,
+    vat_number: user.tva_intra,
+    rcs_rm: user.rcs_ou_rm,
     email: user.email,
     phone: user.phone,
     social_capital: user.social_capital,

--- a/backend/tests/exportHtml.test.js
+++ b/backend/tests/exportHtml.test.js
@@ -26,7 +26,7 @@ describe('GET /api/factures/:id/html', () => {
       phone: "0102030405"
     };
     const profileRes = await request(app)
-      .post('/api/user-profile')
+      .put('/api/profile')
       .set('Authorization', `Bearer ${API_TOKEN}`)
       .send(profilePayload);
     // Check if profile creation was successful, otherwise tests dependent on it will fail.

--- a/backend/tests/seedIfNeeded.test.js
+++ b/backend/tests/seedIfNeeded.test.js
@@ -1,10 +1,8 @@
 const fs = require('fs');
 const path = require('path');
 const SQLiteDatabase = require('../database/sqlite');
-const { readUserProfile } = require('../services/userProfileService');
 
 const dbPath = path.join(__dirname, '..', 'database', 'facturation.sqlite');
-const profilePath = path.join(__dirname, '..', 'data', 'profil_utilisateur.json');
 
 let app;
 
@@ -21,7 +19,6 @@ const waitForSeed = async () => {
 describe('seedIfNeeded() on server startup', () => {
   beforeAll(async () => {
     if (fs.existsSync(dbPath)) fs.unlinkSync(dbPath);
-    if (fs.existsSync(profilePath)) fs.unlinkSync(profilePath);
     jest.resetModules();
     app = await require('../server');
     await waitForSeed();
@@ -32,8 +29,8 @@ describe('seedIfNeeded() on server startup', () => {
     const hasSeeded = db.getMeta('hasSeeded');
     expect(hasSeeded).toBe('true');
     expect(db.getClients().length).toBeGreaterThanOrEqual(1);
-    const profile = await readUserProfile();
-    expect(profile).not.toBeNull();
+    const profile = db.getUserProfile();
+    expect(profile.full_name).toBeTruthy();
   });
 
   test('does not reseed when restarted', async () => {

--- a/backend/tests/testUtils.js
+++ b/backend/tests/testUtils.js
@@ -1,8 +1,5 @@
-const fs = require('fs').promises;
-const path = require('path');
+const SQLiteDatabase = require('../database/sqlite');
 
-const DATA_DIR = path.join(__dirname, '..', 'data');
-const USER_PROFILE_PATH = path.join(DATA_DIR, 'profil_utilisateur.json');
 
 const DUMMY_PROFILE_DATA = {
   raison_sociale: "Test Utility Company",
@@ -18,34 +15,35 @@ const DUMMY_PROFILE_DATA = {
 
 async function setupDummyProfile() {
   try {
-    // Ensure data directory exists
-    await fs.mkdir(DATA_DIR, { recursive: true });
-    // Write the dummy profile
-    await fs.writeFile(USER_PROFILE_PATH, JSON.stringify(DUMMY_PROFILE_DATA, null, 2), 'utf-8');
-    // console.log('Dummy profile created at:', USER_PROFILE_PATH);
+    const db = await SQLiteDatabase.create();
+    db.upsertUserProfile({
+      full_name: DUMMY_PROFILE_DATA.raison_sociale,
+      address_street: DUMMY_PROFILE_DATA.adresse,
+      address_postal_code: DUMMY_PROFILE_DATA.code_postal,
+      address_city: DUMMY_PROFILE_DATA.ville,
+      siret_siren: DUMMY_PROFILE_DATA.siret,
+      ape_naf_code: DUMMY_PROFILE_DATA.ape_naf,
+      vat_number: DUMMY_PROFILE_DATA.tva_intra,
+      legal_form: DUMMY_PROFILE_DATA.forme_juridique,
+      rcs_rm: DUMMY_PROFILE_DATA.rcs_ou_rm
+    });
   } catch (error) {
     console.error('Error setting up dummy profile:', error);
-    // throw error; // rethrow to fail tests if setup is critical
   }
 }
 
 async function cleanupDummyProfile() {
   try {
-    await fs.unlink(USER_PROFILE_PATH);
-    // console.log('Dummy profile cleaned up from:', USER_PROFILE_PATH);
+    const db = await SQLiteDatabase.create();
+    db.db.run('DELETE FROM user_profile');
+    db.save();
   } catch (error) {
-    if (error.code === 'ENOENT') {
-      // File didn't exist, which is fine for cleanup
-      // console.log('Dummy profile file did not exist, no cleanup needed.');
-    } else {
-      console.error('Error cleaning up dummy profile:', error);
-    }
+    console.error('Error cleaning up dummy profile:', error);
   }
 }
 
 module.exports = {
   setupDummyProfile,
   cleanupDummyProfile,
-  DUMMY_PROFILE_DATA,
-  USER_PROFILE_PATH
+  DUMMY_PROFILE_DATA
 };

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -98,7 +98,7 @@ export const apiClient = {
   // getUserProfile now returns the UserProfileJson structure
   getUserProfile: async (): Promise<UserProfileJson> => {
     const token = getAuthToken();
-    const response = await fetch(`${API_URL}/user-profile`, {
+    const response = await fetch(`${API_URL}/profile`, {
       headers: {
         'Authorization': `Bearer ${token}`,
       },
@@ -121,8 +121,8 @@ export const apiClient = {
   // The backend is responsible for mapping these fields to the actual JSON structure.
   updateUserProfile: async (profileData: ProfileDataForUpdate): Promise<UserProfileJson> => {
     const token = getAuthToken();
-    const response = await fetch(`${API_URL}/user-profile`, {
-      method: 'POST',
+    const response = await fetch(`${API_URL}/profile`, {
+      method: 'PUT',
       headers: {
         'Content-Type': 'application/json',
         'Authorization': `Bearer ${token}`,


### PR DESCRIPTION
## Summary
- store user profile in SQLite instead of JSON
- expose GET/PUT `/api/profile`
- keep legacy `/api/user-profile` for compatibility
- refresh profile page on save and show success toast
- update backend and frontend tests for new API

## Testing
- `cd backend && pnpm install && pnpm test`
- `cd frontend && pnpm install && pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_685cb3af2c14832f883badaeabccde41