### PR TITLE
Add MJ Architecture demo client with June 2025 invoices

### DIFF
--- a/backend/scripts/seed-demo-data.js
+++ b/backend/scripts/seed-demo-data.js
@@ -50,13 +50,14 @@ async function seed(dbInstance) {
 
   factures.forEach(f => {
     const clientId = clientIdMap[f.clientKey];
+    const client = clients.find(c => c.nom_entreprise === f.clientKey);
     db.createFacture({
       client_id: clientId,
       numero_facture: f.numero,
-      nom_client: clients[0].nom_client,
-      nom_entreprise: clients[0].nom_entreprise,
-      telephone: clients[0].telephone,
-      adresse: clients[0].adresse_facturation,
+      nom_client: client.nom_client,
+      nom_entreprise: client.nom_entreprise,
+      telephone: client.telephone,
+      adresse: client.adresse_facturation,
       date_facture: f.date,
       montant_total: f.montant,
       status: f.status,

--- a/data/mockData/clients.json
+++ b/data/mockData/clients.json
@@ -9,5 +9,17 @@
     "siret": "11111111100011",
     "legal_form": "SARL",
     "rcs_number": "Basse-Terre 111 111 111"
+  },
+  {
+    "nom_client": "Malik Johnson",
+    "nom_entreprise": "MJ Architecture",
+    "email": "malik@mj-architecture.fr",
+    "telephone": "0611223344",
+    "adresse_facturation": "42 Rue des Bâtisseurs, 75010 Paris",
+    "adresse_livraison": "42 Rue des Bâtisseurs, 75010 Paris",
+    "siret": "11223344556677",
+    "tva": "FR445566778899",
+    "legal_form": "SASU",
+    "rcs_number": "Paris 123 456 789"
   }
 ]

--- a/data/mockData/factures.json
+++ b/data/mockData/factures.json
@@ -30,5 +30,29 @@
     "description": "Carte de visite imprimée",
     "montant": 150,
     "date": "2024-03-20"
+  },
+  {
+    "clientKey": "MJ Architecture",
+    "numero": "F2025-045",
+    "status": "paid",
+    "description": "Consultation chantier - Projet Rivoli",
+    "montant": 950,
+    "date": "2025-06-05"
+  },
+  {
+    "clientKey": "MJ Architecture",
+    "numero": "F2025-052",
+    "status": "unpaid",
+    "description": "Plans de rénovation – Appartement Voltaire",
+    "montant": 1400,
+    "date": "2025-06-15"
+  },
+  {
+    "clientKey": "MJ Architecture",
+    "numero": "F2025-060",
+    "status": "paid",
+    "description": "Mission express – Vérification conformité permis",
+    "montant": 550,
+    "date": "2025-06-25"
   }
 ]


### PR DESCRIPTION
## Summary
- extend mock clients list with MJ Architecture
- add three June 2025 invoices for this client
- associate invoices with their client in the seeding script

## Testing
- `pnpm test` in `backend`
- `pnpm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_685cbd543d20832fa9b2f823be350815