### PR TITLE
Fix monthly status widget

### DIFF
--- a/backend/server.ts
+++ b/backend/server.ts
@@ -868,7 +868,7 @@ app.get('/api/invoices', (req, res, next) => {
     const monthIndex = now.getMonth();
     const factures = db.getFactures();
     const current = factures.filter(f => {
-      const d = new Date(f.date_facture);
+      const d = new Date(f.created_at || f.date_facture);
       return d.getFullYear() === year && d.getMonth() === monthIndex;
     });
     const paid = current.filter(f => f.status === 'paid').length;

--- a/backend/tests/monthInvoices.test.js
+++ b/backend/tests/monthInvoices.test.js
@@ -1,0 +1,50 @@
+const request = require('supertest');
+const { setupDummyProfile, cleanupDummyProfile } = require('./testUtils');
+let app;
+const API_TOKEN = 'test-token';
+
+beforeAll(async () => {
+  await setupDummyProfile();
+  app = await require('../server');
+});
+
+afterAll(async () => {
+  await cleanupDummyProfile();
+});
+
+describe('GET /api/invoices?month=current', () => {
+  test('counts invoices created this month', async () => {
+    const initialRes = await request(app)
+      .get('/api/invoices?month=current')
+      .set('Authorization', `Bearer ${API_TOKEN}`);
+    expect(initialRes.status).toBe(200);
+    const { paid: initPaid = 0, unpaid: initUnpaid = 0 } = initialRes.body;
+
+    await request(app)
+      .post('/api/factures')
+      .set('Authorization', `Bearer ${API_TOKEN}`)
+      .send({
+        nom_client: 'Test Paid',
+        date_facture: '2024-01-01',
+        lignes: [{ description: 'x', quantite: 1, prix_unitaire: 10 }],
+        status: 'paid',
+      });
+
+    await request(app)
+      .post('/api/factures')
+      .set('Authorization', `Bearer ${API_TOKEN}`)
+      .send({
+        nom_client: 'Test Unpaid',
+        date_facture: '2024-01-02',
+        lignes: [{ description: 'y', quantite: 1, prix_unitaire: 15 }],
+        status: 'unpaid',
+      });
+
+    const afterRes = await request(app)
+      .get('/api/invoices?month=current')
+      .set('Authorization', `Bearer ${API_TOKEN}`);
+    expect(afterRes.status).toBe(200);
+    expect(afterRes.body.paid).toBe(initPaid + 1);
+    expect(afterRes.body.unpaid).toBe(initUnpaid + 1);
+  });
+});

--- a/frontend/src/components/cards/InvoicePieChart.tsx
+++ b/frontend/src/components/cards/InvoicePieChart.tsx
@@ -1,13 +1,11 @@
 import { useEffect, useState } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
-import { Switch } from '@/components/ui/switch';
 import { API_URL } from '@/lib/api';
 
 export function InvoicePieChart() {
   const [url, setUrl] = useState('');
   const [stats, setStats] = useState({ paid: 0, unpaid: 0 });
-  const [showPaid, setShowPaid] = useState(false);
 
   useEffect(() => {
     async function load() {
@@ -31,26 +29,27 @@ export function InvoicePieChart() {
       }
     }
     load();
+    const handler = () => load();
+    window.addEventListener('factureChange', handler);
+    window.addEventListener('factureStatutChange', handler);
+    return () => {
+      window.removeEventListener('factureChange', handler);
+      window.removeEventListener('factureStatutChange', handler);
+    };
   }, []);
 
   return (
     <Card>
       <CardHeader>
-        <div className="flex items-center justify-between">
-          <CardTitle>Statut du mois</CardTitle>
-          <div className="flex items-center space-x-2">
-            <Switch checked={showPaid} onCheckedChange={setShowPaid} />
-            <span className="text-sm">
-              {showPaid ? 'Payées' : 'Impayées'}
-            </span>
-          </div>
-        </div>
+        <CardTitle>Statut du mois</CardTitle>
       </CardHeader>
       <CardContent className="text-center">
         {url ? <img src={url} alt="Camembert factures" /> : <Skeleton className="h-40 w-full" />}
         <p className="mt-4 font-medium">
-          {showPaid ? stats.paid : stats.unpaid} facture{(showPaid ? stats.paid : stats.unpaid) > 1 ? 's' : ''}{' '}
-          {showPaid ? 'payée' : 'impayée'}{(showPaid ? stats.paid : stats.unpaid) > 1 ? 's' : ''}
+          {stats.paid + stats.unpaid} facture{stats.paid + stats.unpaid > 1 ? 's' : ''} au total
+        </p>
+        <p className="text-sm text-gray-500 dark:text-gray-400">
+          {stats.paid} payée{stats.paid > 1 ? 's' : ''}, {stats.unpaid} impayée{stats.unpaid > 1 ? 's' : ''}
         </p>
       </CardContent>
     </Card>

--- a/frontend/src/components/cards/StatsCarousel.tsx
+++ b/frontend/src/components/cards/StatsCarousel.tsx
@@ -53,6 +53,16 @@ export function StatsCarousel() {
     }
     loadPie();
     loadUnpaid();
+    const handler = () => {
+      loadPie();
+      loadUnpaid();
+    };
+    window.addEventListener('factureChange', handler);
+    window.addEventListener('factureStatutChange', handler);
+    return () => {
+      window.removeEventListener('factureChange', handler);
+      window.removeEventListener('factureStatutChange', handler);
+    };
   }, []);
 
   useEffect(() => {

--- a/frontend/src/pages/CreerFacture.tsx
+++ b/frontend/src/pages/CreerFacture.tsx
@@ -370,6 +370,7 @@ export default function CreerFacture() {
 
       const data = await response.json();
       toast({ title: 'Facture créée', description: `La facture ${data.numero_facture || numeroFacture} a été créée avec succès.` });
+      window.dispatchEvent(new Event('factureChange'));
       navigate('/factures');
     } catch (err) {
       toast({ title: 'Erreur de création', description: (err instanceof Error ? err.message : 'Une erreur est survenue.'), variant: 'destructive' });

--- a/frontend/src/utils/invoiceService.ts
+++ b/frontend/src/utils/invoiceService.ts
@@ -34,6 +34,7 @@ export async function updateInvoice(id: number, data: Partial<InvoiceType>): Pro
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(data),
   });
+  window.dispatchEvent(new Event('factureChange'));
 }
 
 export async function updateInvoiceStatus(
@@ -79,6 +80,7 @@ export async function updateInvoiceStatus(
   window.dispatchEvent(new CustomEvent('factureStatutChange', {
     detail: updatedInvoice,
   }));
+  window.dispatchEvent(new Event('factureChange'));
 
   return updatedInvoice;
 }


### PR DESCRIPTION
## Summary
- track invoices by `created_at` in `/api/invoices`
- refresh pie chart data whenever invoices change
- display total, paid and unpaid counts in `InvoicePieChart`
- reload carousel stats on invoice changes
- emit a `factureChange` event after creating or editing invoices
- ensure invoices of current month are counted with a new test

## Testing
- `cd backend && pnpm install && pnpm test`
- `cd frontend && pnpm install && pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_685cc9587e30832fb483306f62deb168