### PR TITLE
Refine homepage card styling

### DIFF
--- a/frontend/src/components/cards/QuoteCard.tsx
+++ b/frontend/src/components/cards/QuoteCard.tsx
@@ -25,7 +25,9 @@ export function QuoteCard() {
   }, []);
 
   return (
-    <div className="rounded-xl shadow-md bg-white p-6 transition-all duration-300">
+    <div
+      className="rounded-xl shadow-md border border-zinc-200 dark:border-zinc-800 p-6 transition-all duration-300 w-full bg-gradient-to-br from-[var(--gradient-start)] via-[var(--gradient-mid)] to-[var(--gradient-end)] text-white dark:from-indigo-900 dark:via-violet-900 dark:to-indigo-950"
+    >
       <div className="mb-4">
         <h3 className="font-semibold">Citation du jour</h3>
       </div>

--- a/frontend/src/components/cards/SunsetImageCard.tsx
+++ b/frontend/src/components/cards/SunsetImageCard.tsx
@@ -23,7 +23,9 @@ export function SunsetImageCard() {
   }, []);
 
   return (
-    <div className="rounded-xl shadow-md bg-white p-6 transition-all duration-300 animate-fade-in">
+    <div
+      className="rounded-xl shadow-md border border-zinc-200 dark:border-zinc-800 p-6 transition-all duration-300 w-full animate-fade-in bg-gradient-to-br from-[var(--gradient-start)] via-[var(--gradient-mid)] to-[var(--gradient-end)] text-white dark:from-indigo-900 dark:via-violet-900 dark:to-indigo-950"
+    >
       <div className="mb-4">
         <h3 className="font-semibold">Coucher de soleil</h3>
       </div>


### PR DESCRIPTION
## Summary
- add gradient backgrounds to QuoteCard and SunsetImageCard for a consistent look

## Testing
- `cd backend && pnpm install && pnpm test`
- `cd frontend && pnpm install && pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_685ccb157a78832f861e0adc3237926c