### PR TITLE
Fix widgets caching and invoice stats

### DIFF
--- a/backend/tests/monthInvoices.test.js
+++ b/backend/tests/monthInvoices.test.js
@@ -18,7 +18,11 @@ describe('GET /api/invoices?month=current', () => {
       .get('/api/invoices?month=current')
       .set('Authorization', `Bearer ${API_TOKEN}`);
     expect(initialRes.status).toBe(200);
-    const { paid: initPaid = 0, unpaid: initUnpaid = 0 } = initialRes.body;
+    const {
+      paid: initPaid = 0,
+      unpaid: initUnpaid = 0,
+      total: initTotal = 0,
+    } = initialRes.body;
 
     await request(app)
       .post('/api/factures')
@@ -46,5 +50,48 @@ describe('GET /api/invoices?month=current', () => {
     expect(afterRes.status).toBe(200);
     expect(afterRes.body.paid).toBe(initPaid + 1);
     expect(afterRes.body.unpaid).toBe(initUnpaid + 1);
+    expect(afterRes.body.total).toBe(initTotal + 2);
+  });
+});
+
+describe('GET /api/invoices?month=06&year=2025', () => {
+  test('counts invoices for a specific month', async () => {
+    const initialRes = await request(app)
+      .get('/api/invoices?month=06&year=2025')
+      .set('Authorization', `Bearer ${API_TOKEN}`);
+    expect(initialRes.status).toBe(200);
+    const {
+      paid: initPaid = 0,
+      unpaid: initUnpaid = 0,
+      total: initTotal = 0,
+    } = initialRes.body;
+
+    await request(app)
+      .post('/api/factures')
+      .set('Authorization', `Bearer ${API_TOKEN}`)
+      .send({
+        nom_client: 'June Paid',
+        date_facture: '2025-06-10',
+        lignes: [{ description: 'a', quantite: 1, prix_unitaire: 10 }],
+        status: 'paid',
+      });
+
+    await request(app)
+      .post('/api/factures')
+      .set('Authorization', `Bearer ${API_TOKEN}`)
+      .send({
+        nom_client: 'June Unpaid',
+        date_facture: '2025-06-11',
+        lignes: [{ description: 'b', quantite: 1, prix_unitaire: 15 }],
+        status: 'unpaid',
+      });
+
+    const afterRes = await request(app)
+      .get('/api/invoices?month=06&year=2025')
+      .set('Authorization', `Bearer ${API_TOKEN}`);
+    expect(afterRes.status).toBe(200);
+    expect(afterRes.body.paid).toBe(initPaid + 1);
+    expect(afterRes.body.unpaid).toBe(initUnpaid + 1);
+    expect(afterRes.body.total).toBe(initTotal + 2);
   });
 });

--- a/frontend/src/components/cards/InvoicePieChart.test.tsx
+++ b/frontend/src/components/cards/InvoicePieChart.test.tsx
@@ -4,7 +4,7 @@ jest.mock('@/lib/api', () => ({ API_URL: 'http://localhost:3001/api' }));
 import { InvoicePieChart } from './InvoicePieChart';
 
 const fetchMock = jest.fn().mockResolvedValue({
-  json: () => Promise.resolve({ paid: 3, unpaid: 2 })
+  json: () => Promise.resolve({ total: 5, paid: 3, unpaid: 2 })
 });
 
 global.fetch = fetchMock as any;
@@ -16,4 +16,5 @@ test('génère une url de graphique', async () => {
   );
   const img = await screen.findByRole('img');
   expect(img.getAttribute('src')).toMatch('quickchart.io');
+  expect(await screen.findByText(/5 facture/)).toBeInTheDocument();
 });

--- a/frontend/src/components/cards/InvoicePieChart.tsx
+++ b/frontend/src/components/cards/InvoicePieChart.tsx
@@ -5,7 +5,7 @@ import { API_URL } from '@/lib/api';
 
 export function InvoicePieChart() {
   const [url, setUrl] = useState('');
-  const [stats, setStats] = useState({ paid: 0, unpaid: 0 });
+  const [stats, setStats] = useState({ total: 0, paid: 0, unpaid: 0 });
 
   useEffect(() => {
     async function load() {
@@ -46,7 +46,7 @@ export function InvoicePieChart() {
       <CardContent className="text-center">
         {url ? <img src={url} alt="Camembert factures" /> : <Skeleton className="h-40 w-full" />}
         <p className="mt-4 font-medium">
-          {stats.paid + stats.unpaid} facture{stats.paid + stats.unpaid > 1 ? 's' : ''} au total
+          {stats.total} facture{stats.total > 1 ? 's' : ''} au total
         </p>
         <p className="text-sm text-gray-500 dark:text-gray-400">
           {stats.paid} payée{stats.paid > 1 ? 's' : ''}, {stats.unpaid} impayée{stats.unpaid > 1 ? 's' : ''}

--- a/frontend/src/components/cards/QuoteCard.test.tsx
+++ b/frontend/src/components/cards/QuoteCard.test.tsx
@@ -4,17 +4,21 @@ import { QuoteCard } from './QuoteCard';
 
 // Mock the api module
 jest.mock('@/lib/api', () => ({
-  API_URL: 'http://localhost:3000/api/mock', // Provide a mock API_URL
-  GEMINI_API_KEY: 'mock-gemini-key', // Provide a mock GEMINI_API_KEY
+  API_URL: 'http://localhost:3000/api/mock',
+  GEMINI_API_KEY: 'mock-gemini-key',
 }));
 
-global.fetch = jest.fn().mockResolvedValueOnce({
-  json: () => Promise.resolve({ text: 'bonjour', author: 'me' })
-});
-
 test('affiche la citation', async () => {
+  const fetchMock = jest.fn().mockResolvedValue({
+    json: () => Promise.resolve({ text: 'bonjour', author: 'me' })
+  });
+  (global as any).fetch = fetchMock;
+  localStorage.clear();
   render(<QuoteCard />);
-  await waitFor(() => expect(screen.getByText(/bonjour/)).toBeInTheDocument());
+  await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+  expect(await screen.findByText(/bonjour/)).toBeInTheDocument();
   expect(screen.getByText(/me/)).toBeInTheDocument();
 });
+
+
 

--- a/frontend/src/components/cards/StatsCarousel.tsx
+++ b/frontend/src/components/cards/StatsCarousel.tsx
@@ -20,7 +20,7 @@ interface Facture {
 export function StatsCarousel() {
   const [api, setApi] = useState<CarouselApi>();
   const [index, setIndex] = useState(0);
-  const [pieStats, setPieStats] = useState({ paid: 0, unpaid: 0 });
+  const [pieStats, setPieStats] = useState({ total: 0, paid: 0, unpaid: 0 });
   const [unpaid, setUnpaid] = useState<Facture[]>([]);
 
   const euro = useMemo(
@@ -80,7 +80,7 @@ export function StatsCarousel() {
     [unpaid]
   );
 
-  const invoicesThisMonth = pieStats.paid + pieStats.unpaid;
+  const invoicesThisMonth = pieStats.total;
 
   return (
     <div className="rounded-xl shadow-md bg-white dark:bg-gray-800 p-6 transition-all duration-300 w-full">


### PR DESCRIPTION
## Summary
- cache daily quote locally and refresh at midnight
- expose month/year parameters for `/api/invoices`
- show invoice totals in the Status widget and carousel
- update tests for new behaviour
- clean up quote test duplicates

## Testing
- `cd backend && pnpm install && pnpm test`
- `cd frontend && pnpm install && pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_685cd170378c832fb5c1d10ff33c4e42