### PR TITLE
Fix invoice stats widget

### DIFF
--- a/backend/server.ts
+++ b/backend/server.ts
@@ -861,8 +861,8 @@ app.get('/api/quote', (req, res, next) => {
   }
 });
 
-// Route pour le camembert factures payées vs impayées du mois courant
-app.get('/api/invoices', (req, res, next) => {
+// Route pour obtenir les statistiques de factures d'un mois donné
+app.get('/api/invoices/stats', (req, res, next) => {
   const { month, year } = req.query;
 
   try {
@@ -891,13 +891,16 @@ app.get('/api/invoices', (req, res, next) => {
     }
 
     const factures = db.getFactures();
+    console.log('📊 Fetching stats for:', month, year);
     const filtered = factures.filter(f => {
       const d = new Date(f.created_at || f.date_facture);
       return d.getFullYear() === targetYear && d.getMonth() === targetMonth;
     });
     const paid = filtered.filter(f => f.status === 'paid').length;
     const unpaid = filtered.filter(f => f.status !== 'paid').length;
-    res.json({ total: filtered.length, paid, unpaid });
+    const result = { total: filtered.length, paid, unpaid };
+    console.log('🔢 Stats:', result);
+    res.json(result);
   } catch (err) {
     next(err);
   }

--- a/backend/tests/monthInvoices.test.js
+++ b/backend/tests/monthInvoices.test.js
@@ -12,10 +12,13 @@ afterAll(async () => {
   await cleanupDummyProfile();
 });
 
-describe('GET /api/invoices?month=current', () => {
+describe('GET /api/invoices/stats?month=<now>&year=<now>', () => {
   test('counts invoices created this month', async () => {
+    const now = new Date();
+    const currentMonth = String(now.getMonth() + 1).padStart(2, '0');
+    const currentYear = now.getFullYear();
     const initialRes = await request(app)
-      .get('/api/invoices?month=current')
+      .get(`/api/invoices/stats?month=${currentMonth}&year=${currentYear}`)
       .set('Authorization', `Bearer ${API_TOKEN}`);
     expect(initialRes.status).toBe(200);
     const {
@@ -45,7 +48,7 @@ describe('GET /api/invoices?month=current', () => {
       });
 
     const afterRes = await request(app)
-      .get('/api/invoices?month=current')
+      .get(`/api/invoices/stats?month=${currentMonth}&year=${currentYear}`)
       .set('Authorization', `Bearer ${API_TOKEN}`);
     expect(afterRes.status).toBe(200);
     expect(afterRes.body.paid).toBe(initPaid + 1);
@@ -54,10 +57,10 @@ describe('GET /api/invoices?month=current', () => {
   });
 });
 
-describe('GET /api/invoices?month=06&year=2025', () => {
+describe('GET /api/invoices/stats?month=06&year=2025', () => {
   test('counts invoices for a specific month', async () => {
     const initialRes = await request(app)
-      .get('/api/invoices?month=06&year=2025')
+      .get('/api/invoices/stats?month=06&year=2025')
       .set('Authorization', `Bearer ${API_TOKEN}`);
     expect(initialRes.status).toBe(200);
     const {
@@ -87,7 +90,7 @@ describe('GET /api/invoices?month=06&year=2025', () => {
       });
 
     const afterRes = await request(app)
-      .get('/api/invoices?month=06&year=2025')
+      .get('/api/invoices/stats?month=06&year=2025')
       .set('Authorization', `Bearer ${API_TOKEN}`);
     expect(afterRes.status).toBe(200);
     expect(afterRes.body.paid).toBe(initPaid + 1);

--- a/frontend/src/components/cards/InvoicePieChart.test.tsx
+++ b/frontend/src/components/cards/InvoicePieChart.test.tsx
@@ -12,7 +12,9 @@ global.fetch = fetchMock as any;
 test('génère une url de graphique', async () => {
   render(<InvoicePieChart />);
   await waitFor(() =>
-    expect(fetchMock).toHaveBeenCalledWith(expect.stringContaining('/invoices?month=current'))
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining('/invoices/stats?month=')
+    )
   );
   const img = await screen.findByRole('img');
   expect(img.getAttribute('src')).toMatch('quickchart.io');

--- a/frontend/src/components/cards/InvoicePieChart.tsx
+++ b/frontend/src/components/cards/InvoicePieChart.tsx
@@ -10,8 +10,14 @@ export function InvoicePieChart() {
   useEffect(() => {
     async function load() {
       try {
-        const res = await fetch(`${API_URL}/invoices?month=current`);
+        const now = new Date();
+        const month = now.getMonth() + 1;
+        const year = now.getFullYear();
+        const res = await fetch(
+          `${API_URL}/invoices/stats?month=${month}&year=${year}`
+        );
         const data = await res.json();
+        console.log('📥 Stats data:', data);
         setStats(data);
         const cfg = {
           type: 'pie',

--- a/frontend/src/components/cards/StatsCarousel.tsx
+++ b/frontend/src/components/cards/StatsCarousel.tsx
@@ -32,9 +32,16 @@ export function StatsCarousel() {
   useEffect(() => {
     async function loadPie() {
       try {
-        const r = await fetch(`${API_URL}/invoices?month=current`);
+        const now = new Date();
+        const month = now.getMonth() + 1;
+        const year = now.getFullYear();
+        const r = await fetch(
+          `${API_URL}/invoices/stats?month=${month}&year=${year}`
+        );
         if (r.ok) {
-          setPieStats(await r.json());
+          const d = await r.json();
+          console.log('📥 Stats data:', d);
+          setPieStats(d);
         }
       } catch {
         /* ignore */


### PR DESCRIPTION
## Summary
- expose `/api/invoices/stats` endpoint with debug logs
- request current month stats from `InvoicePieChart` and `StatsCarousel`
- log received data in widgets
- adjust tests for new API endpoint

## Testing
- `cd backend && pnpm install && pnpm test`
- `cd frontend && pnpm install && pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_685dddc040d8832f82f7e05dacf47ba5