### PR TITLE
Fix profile display with demo data

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -108,11 +108,36 @@ export const apiClient = {
       throw new Error(`Failed to fetch user profile: ${response.statusText}`);
     }
     const data = await response.json();
-    // The backend might return data that includes fields beyond the strict UserProfileJson,
-    // (e.g. if it used to use the old DB structure and returns all fields).
-    // Or it might return exactly UserProfileJson.
-    // The type cast here assumes the response is compatible.
-    // ProfilePage.tsx's useEffect handles mapping this to its FormProfileData.
+    console.log('Profil reçu depuis l\'API:', data);
+
+    if ('full_name' in data) {
+      const mapped: UserProfileJson = {
+        raison_sociale: data.full_name || '',
+        adresse: data.address_street || '',
+        code_postal: data.address_postal_code || '',
+        ville: data.address_city || '',
+        forme_juridique: data.legal_form || '',
+        siret: data.siret_siren || '',
+        ape_naf: data.ape_naf_code || '',
+        tva_intra: data.vat_number || '',
+        rcs_ou_rm: data.rcs_rm || '',
+        email: data.email,
+        phone: data.phone,
+        activity_start_date: data.activity_start_date,
+        social_capital: data.social_capital,
+        full_name: data.full_name,
+        address_street: data.address_street,
+        address_postal_code: data.address_postal_code,
+        address_city: data.address_city,
+        siret_siren: data.siret_siren,
+        ape_naf_code: data.ape_naf_code,
+        vat_number: data.vat_number,
+        legal_form: data.legal_form,
+      };
+      return mapped;
+    }
+
+    // Backend might already return the JSON structure
     return data as UserProfileJson;
   },
 

--- a/frontend/src/pages/AfficherProfilUtilisateur.tsx
+++ b/frontend/src/pages/AfficherProfilUtilisateur.tsx
@@ -113,11 +113,11 @@ const AfficherProfilUtilisateur: React.FC = () => {
           <div className="grid grid-cols-1 md:grid-cols-2 gap-x-6 gap-y-3 text-sm">
             <div>
               <p className="font-medium text-gray-500">Raison Sociale</p>
-              <p className="text-gray-900">{profile.raison_sociale || 'N/A'}</p>
+              <p className="text-gray-900">{profile.raison_sociale || '-'}</p>
             </div>
             <div>
               <p className="font-medium text-gray-500">Forme Juridique</p>
-              <p className="text-gray-900">{profile.forme_juridique || 'N/A'}</p>
+              <p className="text-gray-900">{profile.forme_juridique || '-'}</p>
             </div>
             <div className="md:col-span-2">
               <p className="font-medium text-gray-500">Adresse complète</p>
@@ -125,19 +125,19 @@ const AfficherProfilUtilisateur: React.FC = () => {
             </div>
             <div>
               <p className="font-medium text-gray-500">SIRET</p>
-              <p className="text-gray-900">{profile.siret || 'N/A'}</p>
+              <p className="text-gray-900">{profile.siret || '-'}</p>
             </div>
             <div>
               <p className="font-medium text-gray-500">Code APE/NAF</p>
-              <p className="text-gray-900">{profile.ape_naf || 'N/A'}</p>
+              <p className="text-gray-900">{profile.ape_naf || '-'}</p>
             </div>
             <div>
               <p className="font-medium text-gray-500">N° TVA Intracommunautaire</p>
-              <p className="text-gray-900">{profile.tva_intra || 'N/A'}</p>
+              <p className="text-gray-900">{profile.tva_intra || '-'}</p>
             </div>
             <div>
               <p className="font-medium text-gray-500">RCS ou RM</p>
-              <p className="text-gray-900">{profile.rcs_ou_rm || 'N/A'}</p>
+              <p className="text-gray-900">{profile.rcs_ou_rm || '-'}</p>
             </div>
           </div>
           <div className="pt-6 text-center">

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -288,11 +288,11 @@ export default function ProfilePage() {
               <div className="grid grid-cols-1 md:grid-cols-2 gap-x-6 gap-y-3 text-sm">
                 <div>
                   <p className="font-medium text-gray-500">Raison Sociale</p>
-                  <p className="text-gray-900">{userProfile.raison_sociale || 'N/A'}</p>
+                  <p className="text-gray-900">{userProfile.raison_sociale || '-'}</p>
                 </div>
                 <div>
                   <p className="font-medium text-gray-500">Forme Juridique</p>
-                  <p className="text-gray-900">{userProfile.forme_juridique || 'N/A'}</p>
+                  <p className="text-gray-900">{userProfile.forme_juridique || '-'}</p>
                 </div>
                 <div className="md:col-span-2">
                   <p className="font-medium text-gray-500">Adresse complète</p>
@@ -300,19 +300,19 @@ export default function ProfilePage() {
                 </div>
                 <div>
                   <p className="font-medium text-gray-500">SIRET</p>
-                  <p className="text-gray-900">{userProfile.siret || 'N/A'}</p>
+                  <p className="text-gray-900">{userProfile.siret || '-'}</p>
                 </div>
                 <div>
                   <p className="font-medium text-gray-500">Code APE/NAF</p>
-                  <p className="text-gray-900">{userProfile.ape_naf || 'N/A'}</p>
+                  <p className="text-gray-900">{userProfile.ape_naf || '-'}</p>
                 </div>
                 <div>
                   <p className="font-medium text-gray-500">N° TVA Intracommunautaire</p>
-                  <p className="text-gray-900">{userProfile.tva_intra || 'N/A'}</p>
+                  <p className="text-gray-900">{userProfile.tva_intra || '-'}</p>
                 </div>
                 <div>
                   <p className="font-medium text-gray-500">RCS ou RM</p>
-                  <p className="text-gray-900">{userProfile.rcs_ou_rm || 'N/A'}</p>
+                  <p className="text-gray-900">{userProfile.rcs_ou_rm || '-'}</p>
                 </div>
               </div>
               <div className="pt-6 text-center">


### PR DESCRIPTION
## Summary
- map database fields when fetching profile so demo info appears
- show `-` instead of `N/A` on profile display pages

## Testing
- `pnpm test` in `backend`
- `pnpm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_685de247ac98832fb55bb229f3082a2c