### PR TITLE
Fix monthly invoice stats widget

### DIFF
--- a/frontend/jest.setup.ts
+++ b/frontend/jest.setup.ts
@@ -1,3 +1,15 @@
 beforeAll(() => {
   localStorage.setItem('apiToken', 'test-token');
 });
+
+// JSDOM ne gère pas ResizeObserver, nécessaire pour Recharts
+beforeAll(() => {
+  if (typeof window !== 'undefined' && !('ResizeObserver' in window)) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (window as any).ResizeObserver = class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    };
+  }
+});

--- a/frontend/src/components/cards/InvoicePieChart.test.tsx
+++ b/frontend/src/components/cards/InvoicePieChart.test.tsx
@@ -9,14 +9,14 @@ const fetchMock = jest.fn().mockResolvedValue({
 
 global.fetch = fetchMock as any;
 
-test('génère une url de graphique', async () => {
+test('affiche un graphique', async () => {
   render(<InvoicePieChart />);
   await waitFor(() =>
     expect(fetchMock).toHaveBeenCalledWith(
       expect.stringContaining('/invoices/stats?month=')
     )
   );
-  const img = await screen.findByRole('img');
-  expect(img.getAttribute('src')).toMatch('quickchart.io');
+  const chart = await screen.findByTestId('invoice-pie-chart');
+  expect(chart).toBeInTheDocument();
   expect(await screen.findByText(/5 facture/)).toBeInTheDocument();
 });

--- a/frontend/src/components/cards/InvoicePieChart.tsx
+++ b/frontend/src/components/cards/InvoicePieChart.tsx
@@ -2,10 +2,14 @@ import { useEffect, useState } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
 import { API_URL } from '@/lib/api';
+import { PieChart, Pie, Cell, Legend } from 'recharts';
 
 export function InvoicePieChart() {
-  const [url, setUrl] = useState('');
-  const [stats, setStats] = useState({ total: 0, paid: 0, unpaid: 0 });
+  const [stats, setStats] = useState<{
+    total: number;
+    paid: number;
+    unpaid: number;
+  } | null>(null);
 
   useEffect(() => {
     async function load() {
@@ -19,19 +23,8 @@ export function InvoicePieChart() {
         const data = await res.json();
         console.log('📥 Stats data:', data);
         setStats(data);
-        const cfg = {
-          type: 'pie',
-          data: {
-            labels: ['Payées', 'Impayées'],
-            datasets: [{ data: [data.paid, data.unpaid] }],
-          },
-        };
-        setUrl(
-          'https://quickchart.io/chart?c=' +
-            encodeURIComponent(JSON.stringify(cfg))
-        );
       } catch {
-        setUrl('');
+        setStats({ total: 0, paid: 0, unpaid: 0 });
       }
     }
     load();
@@ -52,13 +45,44 @@ export function InvoicePieChart() {
         <CardTitle>Statut du mois</CardTitle>
       </CardHeader>
       <CardContent className="text-center">
-        {url ? <img src={url} alt="Camembert factures" /> : <Skeleton className="h-40 w-full" />}
-        <p className="mt-4 font-medium">
-          {stats.total} facture{stats.total > 1 ? 's' : ''} au total
-        </p>
-        <p className="text-sm text-gray-200">
-          {stats.paid} payée{stats.paid > 1 ? 's' : ''}, {stats.unpaid} impayée{stats.unpaid > 1 ? 's' : ''}
-        </p>
+        {stats === null ? (
+          <Skeleton className="h-40 w-full" />
+        ) : stats.total === 0 ? (
+          <div className="h-40 flex items-center justify-center">
+            Aucune facture ce mois-ci
+          </div>
+        ) : (
+          <PieChart
+            width={200}
+            height={160}
+            data-testid="invoice-pie-chart"
+          >
+            <Pie
+              data={[
+                { name: 'Payées', value: stats.paid },
+                { name: 'Impayées', value: stats.unpaid },
+              ]}
+              dataKey="value"
+              nameKey="name"
+              outerRadius={80}
+            >
+              <Cell fill="#4ade80" />
+              <Cell fill="#f87171" />
+            </Pie>
+            <Legend verticalAlign="bottom" />
+          </PieChart>
+        )}
+        {stats && (
+          <>
+            <p className="mt-4 font-medium">
+              {stats.total} facture{stats.total > 1 ? 's' : ''} au total
+            </p>
+            <p className="text-sm text-gray-200">
+              {stats.paid} payée{stats.paid > 1 ? 's' : ''}, {stats.unpaid}{' '}
+              impayée{stats.unpaid > 1 ? 's' : ''}
+            </p>
+          </>
+        )}
       </CardContent>
     </Card>
   );


### PR DESCRIPTION
## Summary
- replace external QuickChart with local Recharts pie chart
- polyfill `ResizeObserver` for Jest
- update related test to look for the rendered pie chart

## Testing
- `cd backend && pnpm install && pnpm test`
- `cd frontend && pnpm install && pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_685de524dd60832f84eb7b6fde2d3221