### PR TITLE
Fix unpaid invoice widget

### DIFF
--- a/backend/server.ts
+++ b/backend/server.ts
@@ -396,6 +396,7 @@ app.get('/api/factures', (req, res, next) => {
     let statusFilterToApply = status; // req.query.status
     if (!statusFilterToApply && statut) { // req.query.statut
       if (statut === 'payee') statusFilterToApply = 'paid';
+      else if (statut === 'nonpayee' || statut === 'non-payee') statusFilterToApply = 'unpaid';
       else if (statut === 'impayee') statusFilterToApply = 'unpaid';
       // Allow other values if they come directly from 'status'
     }
@@ -896,8 +897,11 @@ app.get('/api/invoices/stats', (req, res, next) => {
       const d = new Date(f.created_at || f.date_facture);
       return d.getFullYear() === targetYear && d.getMonth() === targetMonth;
     });
-    const paid = filtered.filter(f => f.status === 'paid').length;
-    const unpaid = filtered.filter(f => f.status !== 'paid').length;
+    console.log('🧾 Filtered invoices:', filtered);
+    const paidStatuses = ['paid', 'payée'];
+    const unpaidStatuses = ['unpaid', 'non payé', 'non payée', 'impayée'];
+    const paid = filtered.filter(f => paidStatuses.includes(f.status)).length;
+    const unpaid = filtered.filter(f => unpaidStatuses.includes(f.status)).length;
     const result = { total: filtered.length, paid, unpaid };
     console.log('🔢 Stats:', result);
     res.json(result);

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -34,7 +34,7 @@ export default function Sidebar({ open, setOpen }: SidebarProps) {
           <FileText className="h-5 w-5" />
           <span>Toutes les factures</span>
         </NavLink>
-        <NavLink to="/factures?statut=impayee" className="flex items-center space-x-2 text-gray-700 dark:text-gray-300 hover:text-primary dark:hover:text-sky-400">
+        <NavLink to="/factures?statut=nonpayee" className="flex items-center space-x-2 text-gray-700 dark:text-gray-300 hover:text-primary dark:hover:text-sky-400">
           <CircleAlert className="h-5 w-5" />
           <span>Factures non payées</span>
         </NavLink>

--- a/frontend/src/components/cards/InvoicePieChart.tsx
+++ b/frontend/src/components/cards/InvoicePieChart.tsx
@@ -60,7 +60,7 @@ export function InvoicePieChart() {
             <Pie
               data={[
                 { name: 'Payées', value: stats.paid },
-                { name: 'Impayées', value: stats.unpaid },
+                { name: 'Non payées', value: stats.unpaid },
               ]}
               dataKey="value"
               nameKey="name"
@@ -79,7 +79,7 @@ export function InvoicePieChart() {
             </p>
             <p className="text-sm text-gray-200">
               {stats.paid} payée{stats.paid > 1 ? 's' : ''}, {stats.unpaid}{' '}
-              impayée{stats.unpaid > 1 ? 's' : ''}
+              non payée{stats.unpaid > 1 ? 's' : ''}
             </p>
           </>
         )}

--- a/frontend/src/components/clients/CarteClient.tsx
+++ b/frontend/src/components/clients/CarteClient.tsx
@@ -41,7 +41,7 @@ export default function CarteClient({ client }: { client: Client }) {
       {client.nom_entreprise && <div>{client.nom_entreprise}</div>}
       {client.telephone && <div className="text-sm text-gray-500">{client.telephone}</div>}
       <div className="text-xs text-gray-500">
-        {client.totalInvoices ?? (client.factures ? client.factures.length : 0)} factures, {client.unpaidInvoices ?? 0} impayées
+        {client.totalInvoices ?? (client.factures ? client.factures.length : 0)} factures, {client.unpaidInvoices ?? 0} non payées
       </div>
       <Link to={`/clients/${client.id}`} className="text-blue-600 text-sm hover:underline">
         Voir fiche

--- a/frontend/src/pages/Clients.tsx
+++ b/frontend/src/pages/Clients.tsx
@@ -494,7 +494,7 @@ export default function Clients() {
                 {c.email && <div>Email : {c.email}</div>}
                 {c.tva && <div>TVA: {c.tva}</div>}
                 <div className="text-xs text-zinc-500">
-                  {c.totalInvoices ?? (c.factures || []).length} factures, {c.unpaidInvoices ?? 0} impayées
+                  {c.totalInvoices ?? (c.factures || []).length} factures, {c.unpaidInvoices ?? 0} non payées
                 </div>
                 <div>
                   <Link

--- a/frontend/src/pages/ListeFactures.tsx
+++ b/frontend/src/pages/ListeFactures.tsx
@@ -79,7 +79,7 @@ export default function ListeFactures() {
       params.set('dateDebut', dateDebut);
       params.set('dateFin', dateFin);
       if (statusFilter) {
-        params.set('statut', statusFilter === 'paid' ? 'payee' : 'impayee');
+        params.set('statut', statusFilter === 'paid' ? 'payee' : 'nonpayee');
       }
       params.set('sortBy', sortField);
       params.set('order', sortOrder);
@@ -114,7 +114,9 @@ export default function ListeFactures() {
     const st = params.get('status');
     const statut = params.get('statut');
     if (statut) {
-      setStatusFilter(statut === 'payee' ? 'paid' : 'unpaid');
+      setStatusFilter(
+        statut === 'payee' ? 'paid' : statut === 'nonpayee' ? 'unpaid' : 'unpaid'
+      );
     } else if (st) {
       setStatusFilter(st);
     }

--- a/frontend/src/pages/profiles/ClientProfile.tsx
+++ b/frontend/src/pages/profiles/ClientProfile.tsx
@@ -108,7 +108,7 @@ export default function ClientProfile() {
             <div>N° TVA : {client.tva || '-'}</div>
           </fieldset>
 
-          <div>{client.totalInvoices ?? (client.factures || []).length} factures, {client.unpaidInvoices ?? 0} impayées</div>
+          <div>{client.totalInvoices ?? (client.factures || []).length} factures, {client.unpaidInvoices ?? 0} non payées</div>
         </CardContent>
       </Card>
     </div>


### PR DESCRIPTION
## Summary
- update invoice stats endpoint to handle `non payé` statuses and log data
- show 'Non payées' label in pie chart and client cards
- use `statut=nonpayee` when filtering invoices
- map new status in API filter

## Testing
- `cd backend && pnpm install && pnpm test`
- `cd frontend && pnpm install && pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_685de8de46cc832fbaa040442fd38d32