### PR TITLE
Fix monthly invoice stats display

### DIFF
--- a/backend/server.ts
+++ b/backend/server.ts
@@ -902,7 +902,7 @@ app.get('/api/invoices/stats', (req, res, next) => {
     const unpaidStatuses = ['unpaid', 'non payé', 'non payée', 'impayée'];
     const paid = filtered.filter(f => paidStatuses.includes(f.status)).length;
     const unpaid = filtered.filter(f => unpaidStatuses.includes(f.status)).length;
-    const result = { total: filtered.length, paid, unpaid };
+    const result = { total: filtered.length, payees: paid, non_payees: unpaid };
     console.log('🔢 Stats:', result);
     res.json(result);
   } catch (err) {

--- a/backend/tests/monthInvoices.test.js
+++ b/backend/tests/monthInvoices.test.js
@@ -22,8 +22,8 @@ describe('GET /api/invoices/stats?month=<now>&year=<now>', () => {
       .set('Authorization', `Bearer ${API_TOKEN}`);
     expect(initialRes.status).toBe(200);
     const {
-      paid: initPaid = 0,
-      unpaid: initUnpaid = 0,
+      payees: initPaid = 0,
+      non_payees: initUnpaid = 0,
       total: initTotal = 0,
     } = initialRes.body;
 
@@ -51,8 +51,8 @@ describe('GET /api/invoices/stats?month=<now>&year=<now>', () => {
       .get(`/api/invoices/stats?month=${currentMonth}&year=${currentYear}`)
       .set('Authorization', `Bearer ${API_TOKEN}`);
     expect(afterRes.status).toBe(200);
-    expect(afterRes.body.paid).toBe(initPaid + 1);
-    expect(afterRes.body.unpaid).toBe(initUnpaid + 1);
+    expect(afterRes.body.payees).toBe(initPaid + 1);
+    expect(afterRes.body.non_payees).toBe(initUnpaid + 1);
     expect(afterRes.body.total).toBe(initTotal + 2);
   });
 });
@@ -64,8 +64,8 @@ describe('GET /api/invoices/stats?month=06&year=2025', () => {
       .set('Authorization', `Bearer ${API_TOKEN}`);
     expect(initialRes.status).toBe(200);
     const {
-      paid: initPaid = 0,
-      unpaid: initUnpaid = 0,
+      payees: initPaid = 0,
+      non_payees: initUnpaid = 0,
       total: initTotal = 0,
     } = initialRes.body;
 
@@ -93,8 +93,8 @@ describe('GET /api/invoices/stats?month=06&year=2025', () => {
       .get('/api/invoices/stats?month=06&year=2025')
       .set('Authorization', `Bearer ${API_TOKEN}`);
     expect(afterRes.status).toBe(200);
-    expect(afterRes.body.paid).toBe(initPaid + 1);
-    expect(afterRes.body.unpaid).toBe(initUnpaid + 1);
+    expect(afterRes.body.payees).toBe(initPaid + 1);
+    expect(afterRes.body.non_payees).toBe(initUnpaid + 1);
     expect(afterRes.body.total).toBe(initTotal + 2);
   });
 });

--- a/frontend/src/components/cards/InvoicePieChart.test.tsx
+++ b/frontend/src/components/cards/InvoicePieChart.test.tsx
@@ -4,7 +4,7 @@ jest.mock('@/lib/api', () => ({ API_URL: 'http://localhost:3001/api' }));
 import { InvoicePieChart } from './InvoicePieChart';
 
 const fetchMock = jest.fn().mockResolvedValue({
-  json: () => Promise.resolve({ total: 5, paid: 3, unpaid: 2 })
+  json: () => Promise.resolve({ total: 5, payees: 3, non_payees: 2 })
 });
 
 global.fetch = fetchMock as any;

--- a/frontend/src/components/cards/InvoicePieChart.tsx
+++ b/frontend/src/components/cards/InvoicePieChart.tsx
@@ -7,8 +7,8 @@ import { PieChart, Pie, Cell, Legend } from 'recharts';
 export function InvoicePieChart() {
   const [stats, setStats] = useState<{
     total: number;
-    paid: number;
-    unpaid: number;
+    payees: number;
+    non_payees: number;
   } | null>(null);
 
   useEffect(() => {
@@ -21,10 +21,10 @@ export function InvoicePieChart() {
           `${API_URL}/invoices/stats?month=${month}&year=${year}`
         );
         const data = await res.json();
-        console.log('📥 Stats data:', data);
+        console.log('Statistiques récupérées :', data);
         setStats(data);
       } catch {
-        setStats({ total: 0, paid: 0, unpaid: 0 });
+        setStats({ total: 0, payees: 0, non_payees: 0 });
       }
     }
     load();
@@ -59,8 +59,8 @@ export function InvoicePieChart() {
           >
             <Pie
               data={[
-                { name: 'Payées', value: stats.paid },
-                { name: 'Non payées', value: stats.unpaid },
+                { name: 'Payées', value: stats.payees },
+                { name: 'Non payées', value: stats.non_payees },
               ]}
               dataKey="value"
               nameKey="name"
@@ -78,8 +78,8 @@ export function InvoicePieChart() {
               {stats.total} facture{stats.total > 1 ? 's' : ''} au total
             </p>
             <p className="text-sm text-gray-200">
-              {stats.paid} payée{stats.paid > 1 ? 's' : ''}, {stats.unpaid}{' '}
-              non payée{stats.unpaid > 1 ? 's' : ''}
+              {stats.payees} payée{stats.payees > 1 ? 's' : ''}, {stats.non_payees}{' '}
+              non payée{stats.non_payees > 1 ? 's' : ''}
             </p>
           </>
         )}

--- a/frontend/src/components/cards/StatsCarousel.tsx
+++ b/frontend/src/components/cards/StatsCarousel.tsx
@@ -20,7 +20,7 @@ interface Facture {
 export function StatsCarousel() {
   const [api, setApi] = useState<CarouselApi>();
   const [index, setIndex] = useState(0);
-  const [pieStats, setPieStats] = useState({ total: 0, paid: 0, unpaid: 0 });
+  const [pieStats, setPieStats] = useState({ total: 0, payees: 0, non_payees: 0 });
   const [unpaid, setUnpaid] = useState<Facture[]>([]);
 
   const euro = useMemo(
@@ -40,7 +40,7 @@ export function StatsCarousel() {
         );
         if (r.ok) {
           const d = await r.json();
-          console.log('📥 Stats data:', d);
+          console.log('Statistiques récupérées :', d);
           setPieStats(d);
         }
       } catch {


### PR DESCRIPTION
## Summary
- rename invoice stats fields to `payees` and `non_payees` in the API
- log retrieved statistics in the carousel and pie chart widgets
- update monthly status widget to use the new keys
- adjust corresponding unit tests

## Testing
- `pnpm test` in `backend`
- `pnpm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_685dec38593c832f8e360ce5519ae0cb