### PR TITLE
Add global invoice summary widget

### DIFF
--- a/backend/server.ts
+++ b/backend/server.ts
@@ -910,6 +910,20 @@ app.get('/api/invoices/stats', (req, res, next) => {
   }
 });
 
+// Route pour obtenir un résumé global des factures payées et non payées
+app.get('/api/invoices/summary', (req, res, next) => {
+  try {
+    const factures = db.getFactures();
+    const paidStatuses = ['paid', 'payée'];
+    const unpaidStatuses = ['unpaid', 'non payé', 'non payée', 'impayée'];
+    const paid = factures.filter(f => paidStatuses.includes(f.status)).length;
+    const unpaid = factures.filter(f => unpaidStatuses.includes(f.status)).length;
+    res.json({ payees: paid, non_payees: unpaid });
+  } catch (err) {
+    next(err);
+  }
+});
+
 // Route de statistiques
 app.get('/api/stats', (req, res, next) => {
   try {

--- a/backend/tests/invoiceSummary.test.js
+++ b/backend/tests/invoiceSummary.test.js
@@ -1,0 +1,50 @@
+const request = require('supertest');
+const { setupDummyProfile, cleanupDummyProfile } = require('./testUtils');
+let app;
+const API_TOKEN = 'test-token';
+
+beforeAll(async () => {
+  await setupDummyProfile();
+  app = await require('../server');
+});
+
+afterAll(async () => {
+  await cleanupDummyProfile();
+});
+
+describe('GET /api/invoices/summary', () => {
+  test('counts paid and unpaid invoices', async () => {
+    const before = await request(app)
+      .get('/api/invoices/summary')
+      .set('Authorization', `Bearer ${API_TOKEN}`);
+    expect(before.status).toBe(200);
+    const { payees: initPaid = 0, non_payees: initUnpaid = 0 } = before.body;
+
+    await request(app)
+      .post('/api/factures')
+      .set('Authorization', `Bearer ${API_TOKEN}`)
+      .send({
+        nom_client: 'Summary Paid',
+        date_facture: '2024-01-01',
+        lignes: [{ description: 'a', quantite: 1, prix_unitaire: 10 }],
+        status: 'paid',
+      });
+
+    await request(app)
+      .post('/api/factures')
+      .set('Authorization', `Bearer ${API_TOKEN}`)
+      .send({
+        nom_client: 'Summary Unpaid',
+        date_facture: '2024-01-02',
+        lignes: [{ description: 'b', quantite: 1, prix_unitaire: 15 }],
+        status: 'unpaid',
+      });
+
+    const after = await request(app)
+      .get('/api/invoices/summary')
+      .set('Authorization', `Bearer ${API_TOKEN}`);
+    expect(after.status).toBe(200);
+    expect(after.body.payees).toBe(initPaid + 1);
+    expect(after.body.non_payees).toBe(initUnpaid + 1);
+  });
+});

--- a/frontend/src/components/cards/StatsCarousel.tsx
+++ b/frontend/src/components/cards/StatsCarousel.tsx
@@ -10,7 +10,7 @@ import {
   type CarouselApi,
 } from '@/components/ui/carousel';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { InvoicePieChart } from './InvoicePieChart';
+import { TotalInvoicesPie } from './TotalInvoicesPie';
 import { API_URL } from '@/lib/api';
 
 interface Facture {
@@ -101,7 +101,7 @@ export function StatsCarousel() {
               transition={{ duration: 0.3 }}
             >
               <Link to="/factures?status=unpaid" className="block">
-                <InvoicePieChart />
+                <TotalInvoicesPie />
               </Link>
             </motion.div>
           </CarouselItem>

--- a/frontend/src/components/cards/TotalInvoicesPie.test.tsx
+++ b/frontend/src/components/cards/TotalInvoicesPie.test.tsx
@@ -1,21 +1,17 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 jest.mock('@/lib/api', () => ({ API_URL: 'http://localhost:3001/api' }));
-import { InvoicePieChart } from './InvoicePieChart';
+import { TotalInvoicesPie } from './TotalInvoicesPie';
 
 const fetchMock = jest.fn().mockResolvedValue({
-  json: () => Promise.resolve({ total: 5, payees: 3, non_payees: 2 })
+  json: () => Promise.resolve({ payees: 3, non_payees: 2 })
 });
 
 global.fetch = fetchMock as any;
 
 test('affiche un graphique', async () => {
-  render(<InvoicePieChart />);
-  await waitFor(() =>
-    expect(fetchMock).toHaveBeenCalledWith(
-      expect.stringContaining('/invoices/stats?month=')
-    )
-  );
+  render(<TotalInvoicesPie />);
+  await waitFor(() => expect(fetchMock).toHaveBeenCalledWith('/api/invoices/summary'));
   const chart = await screen.findByTestId('invoice-pie-chart');
   expect(chart).toBeInTheDocument();
   expect(await screen.findByText(/5 facture/)).toBeInTheDocument();

--- a/frontend/src/components/cards/TotalInvoicesPie.tsx
+++ b/frontend/src/components/cards/TotalInvoicesPie.tsx
@@ -3,34 +3,18 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
 import { PieChart, Pie, Cell, Legend } from 'recharts';
 
-export function InvoicePieChart() {
-  const [stats, setStats] = useState<{
-    total: number;
-    payees: number;
-    non_payees: number;
-  } | null>(null);
+export function TotalInvoicesPie() {
+  const [stats, setStats] = useState<{ payees: number; non_payees: number } | null>(null);
 
   useEffect(() => {
     async function load() {
       try {
-        const now = new Date();
-        const monthIndex = now.getMonth();
-        const year = now.getFullYear();
-        const formattedMonth = String(monthIndex + 1).padStart(2, '0');
-        console.log('Fetching stats for:', formattedMonth, year);
-        const res = await fetch(
-          `/api/invoices/stats?month=${formattedMonth}&year=${year}`
-        );
+        const res = await fetch('/api/invoices/summary');
         const data = await res.json();
-        console.log('Statistiques récupérées :', data);
-        const {
-          total = 0,
-          payees = 0,
-          non_payees = 0
-        } = data || {};
-        setStats({ total, payees, non_payees });
+        const { payees = 0, non_payees = 0 } = data || {};
+        setStats({ payees, non_payees });
       } catch {
-        setStats({ total: 0, payees: 0, non_payees: 0 });
+        setStats({ payees: 0, non_payees: 0 });
       }
     }
     load();
@@ -43,26 +27,22 @@ export function InvoicePieChart() {
     };
   }, []);
 
+  const total = stats ? stats.payees + stats.non_payees : 0;
+
   return (
-    <Card
-      className="w-full transition-all duration-300 hover:-translate-y-1 hover:shadow-lg bg-gradient-to-br from-[var(--gradient-start)] via-[var(--gradient-mid)] to-[var(--gradient-end)] text-white dark:from-indigo-900 dark:via-violet-900 dark:to-indigo-950"
-    >
+    <Card className="w-full transition-all duration-300 hover:-translate-y-1 hover:shadow-lg bg-gradient-to-br from-[var(--gradient-start)] via-[var(--gradient-mid)] to-[var(--gradient-end)] text-white dark:from-indigo-900 dark:via-violet-900 dark:to-indigo-950">
       <CardHeader>
-        <CardTitle>Statut du mois</CardTitle>
+        <CardTitle>Répartition des factures</CardTitle>
       </CardHeader>
       <CardContent className="text-center">
         {stats === null ? (
           <Skeleton className="h-40 w-full" />
-        ) : stats.total === 0 ? (
+        ) : total === 0 ? (
           <div className="h-40 flex items-center justify-center">
-            Aucune facture ce mois-ci
+            Aucune facture enregistrée
           </div>
         ) : (
-          <PieChart
-            width={200}
-            height={160}
-            data-testid="invoice-pie-chart"
-          >
+          <PieChart width={200} height={160} data-testid="invoice-pie-chart">
             <Pie
               data={[
                 { name: 'Payées', value: stats.payees },
@@ -81,7 +61,7 @@ export function InvoicePieChart() {
         {stats && (
           <>
             <p className="mt-4 font-medium">
-              {stats.total} facture{stats.total > 1 ? 's' : ''} au total
+              {total} facture{total > 1 ? 's' : ''} au total
             </p>
             <p className="text-sm text-gray-200">
               {stats.payees} payée{stats.payees > 1 ? 's' : ''}, {stats.non_payees}{' '}

--- a/frontend/src/components/cards/index.ts
+++ b/frontend/src/components/cards/index.ts
@@ -1,6 +1,6 @@
 export * from './FunFactCard';
 export * from './WeatherClockCard';
-export * from './InvoicePieChart';
+export * from './TotalInvoicesPie';
 export * from './ApiInfoCard';
 export * from './QuoteCard';
 export * from './SunsetImageCard';


### PR DESCRIPTION
## Summary
- add `/api/invoices/summary` endpoint to count paid and unpaid invoices
- create `TotalInvoicesPie` widget replacing `InvoicePieChart`
- update carousel to use new widget
- test the new backend route and frontend component

## Testing
- `cd backend && pnpm install && pnpm test`
- `cd frontend && pnpm install && pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_685df1fabd2c832f8c3470a3ce0b0641