### PR TITLE
Fix invoice summary fetch with auth

### DIFF
--- a/frontend/src/components/cards/TotalInvoicesPie.test.tsx
+++ b/frontend/src/components/cards/TotalInvoicesPie.test.tsx
@@ -1,17 +1,18 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
-jest.mock('@/lib/api', () => ({ API_URL: 'http://localhost:3001/api' }));
+
+const mockGetInvoiceSummary = jest.fn().mockResolvedValue({ payees: 3, non_payees: 2 });
+
+jest.mock('@/lib/api', () => ({
+  apiClient: { getInvoiceSummary: mockGetInvoiceSummary }
+}));
+
+import { apiClient } from '@/lib/api';
 import { TotalInvoicesPie } from './TotalInvoicesPie';
-
-const fetchMock = jest.fn().mockResolvedValue({
-  json: () => Promise.resolve({ payees: 3, non_payees: 2 })
-});
-
-global.fetch = fetchMock as any;
 
 test('affiche un graphique', async () => {
   render(<TotalInvoicesPie />);
-  await waitFor(() => expect(fetchMock).toHaveBeenCalledWith('/api/invoices/summary'));
+  await waitFor(() => expect(apiClient.getInvoiceSummary).toHaveBeenCalled());
   const chart = await screen.findByTestId('invoice-pie-chart');
   expect(chart).toBeInTheDocument();
   expect(await screen.findByText(/5 facture/)).toBeInTheDocument();

--- a/frontend/src/components/cards/TotalInvoicesPie.tsx
+++ b/frontend/src/components/cards/TotalInvoicesPie.tsx
@@ -2,18 +2,21 @@ import { useEffect, useState } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
 import { PieChart, Pie, Cell, Legend } from 'recharts';
+import { apiClient } from '@/lib/api';
 
 export function TotalInvoicesPie() {
   const [stats, setStats] = useState<{ payees: number; non_payees: number } | null>(null);
 
   useEffect(() => {
+    console.log('TotalInvoicesPie mounted');
     async function load() {
       try {
-        const res = await fetch('/api/invoices/summary');
-        const data = await res.json();
+        const data = await apiClient.getInvoiceSummary();
+        console.log('Fetched invoice summary:', data);
         const { payees = 0, non_payees = 0 } = data || {};
         setStats({ payees, non_payees });
-      } catch {
+      } catch (err) {
+        console.error('Fetch error:', err);
         setStats({ payees: 0, non_payees: 0 });
       }
     }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -219,5 +219,18 @@ export const apiClient = {
     }
     return response.json();
   },
+
+  getInvoiceSummary: async (): Promise<{ payees: number; non_payees: number }> => {
+    const token = getAuthToken();
+    const response = await fetch(`${API_URL}/invoices/summary`, {
+      headers: {
+        'Authorization': `Bearer ${token}`,
+      },
+    });
+    if (!response.ok) {
+      throw new Error(`Failed to fetch invoice summary: ${response.statusText}`);
+    }
+    return response.json();
+  },
   // ... other existing api client methods if any
 };


### PR DESCRIPTION
## Summary
- add `getInvoiceSummary` API helper
- fetch invoice summary via api client and log results in `TotalInvoicesPie`
- update unit test for widget

## Testing
- `cd backend && pnpm install && pnpm test`
- `cd frontend && pnpm install && pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_685e01d8b388832f8556fd410023fb7f