### PR TITLE
Implement shared invoices context

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,7 @@
 import { BrowserRouter as Router } from 'react-router-dom'
 import './App.css'
 import Layout from './Layout'
+import { InvoicesProvider } from './context/InvoicesContext'
 import { ErrorBoundary } from './components/ErrorBoundary'
 import { ThemeProvider } from 'next-themes'
 import { Toaster } from './components/ui/sonner'
@@ -9,10 +10,12 @@ function App() {
   return (
     <ErrorBoundary>
       <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
-        <Router>
-          <Toaster />
-          <Layout />
-        </Router>
+        <InvoicesProvider>
+          <Router>
+            <Toaster />
+            <Layout />
+          </Router>
+        </InvoicesProvider>
       </ThemeProvider>
     </ErrorBoundary>
   )

--- a/frontend/src/components/cards/TotalInvoicesPie.test.tsx
+++ b/frontend/src/components/cards/TotalInvoicesPie.test.tsx
@@ -1,19 +1,28 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
-
-const mockGetInvoiceSummary = jest.fn().mockResolvedValue({ payees: 3, non_payees: 2 });
-
-jest.mock('@/lib/api', () => ({
-  apiClient: { getInvoiceSummary: mockGetInvoiceSummary }
-}));
-
-import { apiClient } from '@/lib/api';
+import { InvoicesProvider } from '@/context/InvoicesContext';
 import { TotalInvoicesPie } from './TotalInvoicesPie';
 
+jest.mock('@/lib/api', () => ({ API_URL: 'http://localhost' }));
+
 test('affiche un graphique', async () => {
-  render(<TotalInvoicesPie />);
-  await waitFor(() => expect(apiClient.getInvoiceSummary).toHaveBeenCalled());
+  global.fetch = jest.fn().mockResolvedValueOnce({
+    ok: true,
+    json: () =>
+      Promise.resolve({ invoices: [
+        { id: 1, status: 'paid' },
+        { id: 2, status: 'unpaid' },
+        { id: 3, status: 'paid' },
+      ] })
+  }) as any;
+
+  render(
+    <InvoicesProvider>
+      <TotalInvoicesPie />
+    </InvoicesProvider>
+  );
+
   const chart = await screen.findByTestId('invoice-pie-chart');
   expect(chart).toBeInTheDocument();
-  expect(await screen.findByText(/5 facture/)).toBeInTheDocument();
+  expect(await screen.findByText(/3 facture/)).toBeInTheDocument();
 });

--- a/frontend/src/components/cards/TotalInvoicesPie.tsx
+++ b/frontend/src/components/cards/TotalInvoicesPie.tsx
@@ -1,30 +1,14 @@
-import { useEffect, useState } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
 import { PieChart, Pie, Cell, Legend } from 'recharts';
-import { apiClient } from '@/lib/api';
+import { useInvoices } from '@/context/InvoicesContext';
+
+function SkeletonPie() {
+  return <Skeleton className="h-40 w-full" />;
+}
 
 export function TotalInvoicesPie() {
-  const [stats, setStats] = useState<{ payees: number; non_payees: number } | null>(null);
-
-  useEffect(() => {
-    const fetchSummary = () => {
-      apiClient
-        .getInvoiceSummary()
-        .then(data => setStats({ payees: data.payees ?? 0, non_payees: data.non_payees ?? 0 }))
-        .catch(console.error);
-    };
-
-    fetchSummary();
-
-    const handler = () => fetchSummary();
-
-    window.addEventListener('factureChange', handler);
-
-    return () => window.removeEventListener('factureChange', handler);
-  }, []);
-
-  const total = stats ? stats.payees + stats.non_payees : 0;
+  const { total, payees, nonPayees, isLoading } = useInvoices();
 
   return (
     <Card className="w-full transition-all duration-300 hover:-translate-y-1 hover:shadow-lg bg-gradient-to-br from-[var(--gradient-start)] via-[var(--gradient-mid)] to-[var(--gradient-end)] text-white dark:from-indigo-900 dark:via-violet-900 dark:to-indigo-950">
@@ -32,18 +16,16 @@ export function TotalInvoicesPie() {
         <CardTitle>Répartition des factures</CardTitle>
       </CardHeader>
       <CardContent className="text-center">
-        {stats === null ? (
-          <Skeleton className="h-40 w-full" />
+        {isLoading ? (
+          <SkeletonPie />
         ) : total === 0 ? (
-          <div className="h-40 flex items-center justify-center">
-            Aucune facture enregistrée
-          </div>
+          <div className="h-40 flex items-center justify-center">Aucune facture enregistrée</div>
         ) : (
           <PieChart width={200} height={160} data-testid="invoice-pie-chart">
             <Pie
               data={[
-                { name: 'Payées', value: stats.payees },
-                { name: 'Non payées', value: stats.non_payees },
+                { name: 'Payées', value: payees },
+                { name: 'Non payées', value: nonPayees },
               ]}
               dataKey="value"
               nameKey="name"
@@ -55,14 +37,13 @@ export function TotalInvoicesPie() {
             <Legend verticalAlign="bottom" />
           </PieChart>
         )}
-        {stats && (
+        {!isLoading && (
           <>
             <p className="mt-4 font-medium">
               {total} facture{total > 1 ? 's' : ''} au total
             </p>
             <p className="text-sm text-gray-200">
-              {stats.payees} payée{stats.payees > 1 ? 's' : ''}, {stats.non_payees}{' '}
-              non payée{stats.non_payees > 1 ? 's' : ''}
+              {payees} payée{payees > 1 ? 's' : ''}, {nonPayees} non payée{nonPayees > 1 ? 's' : ''}
             </p>
           </>
         )}

--- a/frontend/src/context/InvoicesContext.tsx
+++ b/frontend/src/context/InvoicesContext.tsx
@@ -1,0 +1,74 @@
+import React, { createContext, useContext, useEffect, useState, useCallback, useRef } from 'react';
+import { API_URL } from '@/lib/api';
+
+export interface Invoice {
+  id: number;
+  status?: 'paid' | 'unpaid';
+  [key: string]: any;
+}
+
+interface InvoicesContextValue {
+  invoices: Invoice[];
+  isLoading: boolean;
+  error: string | null;
+  total: number;
+  payees: number;
+  nonPayees: number;
+  refresh: () => Promise<void>;
+}
+
+const InvoicesContext = createContext<InvoicesContextValue | undefined>(undefined);
+
+export function InvoicesProvider({ children }: { children: React.ReactNode }) {
+  const [invoices, setInvoices] = useState<Invoice[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const fetched = useRef(false);
+
+  const fetchInvoices = useCallback(async () => {
+    if (fetched.current) return;
+    fetched.current = true;
+    setIsLoading(true);
+    try {
+      const res = await fetch(`${API_URL}/invoices`);
+      if (!res.ok) throw new Error('Erreur lors du chargement des factures');
+      const data = await res.json();
+      setInvoices(data.invoices || data);
+    } catch (e: any) {
+      setError(e.message || 'Erreur inconnue');
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  const refresh = useCallback(async () => {
+    fetched.current = false;
+    await fetchInvoices();
+  }, [fetchInvoices]);
+
+  useEffect(() => {
+    fetchInvoices();
+  }, [fetchInvoices]);
+
+  const payees = invoices.filter(i => i.status === 'paid').length;
+  const total = invoices.length;
+  const nonPayees = total - payees;
+
+  const value: InvoicesContextValue = {
+    invoices,
+    isLoading,
+    error,
+    total,
+    payees,
+    nonPayees,
+    refresh,
+  };
+
+  return <InvoicesContext.Provider value={value}>{children}</InvoicesContext.Provider>;
+}
+
+export function useInvoices() {
+  const ctx = useContext(InvoicesContext);
+  if (!ctx) throw new Error('useInvoices must be used within an InvoicesProvider');
+  return ctx;
+}

--- a/frontend/src/pages/CreerFacture.tsx
+++ b/frontend/src/pages/CreerFacture.tsx
@@ -7,6 +7,7 @@ import { getUserProfileFromLocal, fetchAndSyncUserProfile } from '@/utils/userPr
 import { computeTotals } from '@/lib/utils';
 import { useToast } from '@/hooks/use-toast';
 import numeral from 'numeral';
+import { useInvoices } from '@/context/InvoicesContext';
 
 interface LigneFacture {
   description: string;
@@ -64,6 +65,7 @@ interface SellerProfileState {
 export default function CreerFacture() {
   const navigate = useNavigate();
   const { toast } = useToast();
+  const { refresh } = useInvoices();
   const goBack = () => (window.history.length > 1 ? navigate(-1) : navigate('/'));
   
   // Client & Invoice specific states
@@ -371,6 +373,7 @@ export default function CreerFacture() {
       const data = await response.json();
       toast({ title: 'Facture créée', description: `La facture ${data.numero_facture || numeroFacture} a été créée avec succès.` });
       window.dispatchEvent(new Event('factureChange'));
+      await refresh();
       navigate('/factures');
     } catch (err) {
       toast({ title: 'Erreur de création', description: (err instanceof Error ? err.message : 'Une erreur est survenue.'), variant: 'destructive' });

--- a/frontend/src/pages/DetailFacture.tsx
+++ b/frontend/src/pages/DetailFacture.tsx
@@ -8,6 +8,7 @@ import { computeTotals } from '@/lib/utils';
 import { format } from 'date-fns';
 import { fr } from 'date-fns/locale';
 import StatutBadge from '@/components/StatutBadge';
+import { useInvoices } from '@/context/InvoicesContext';
 
 interface Facture {
   id: number;
@@ -45,6 +46,7 @@ interface LigneFacture {
 export default function DetailFacture() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
+  const { refresh } = useInvoices();
   const [facture, setFacture] = useState<Facture | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -94,6 +96,7 @@ export default function DetailFacture() {
 
       alert('Facture supprimée avec succès');
       window.dispatchEvent(new Event('factureChange'));
+      await refresh();
       navigate('/factures');
     } catch (err) {
       alert(err instanceof Error ? err.message : 'Erreur lors de la suppression');

--- a/frontend/src/pages/ListeFactures.test.tsx
+++ b/frontend/src/pages/ListeFactures.test.tsx
@@ -2,11 +2,12 @@ import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { BrowserRouter } from 'react-router-dom';
 import ListeFactures from './ListeFactures';
+import { InvoicesProvider } from '@/context/InvoicesContext';
 
 // Mock the api module
 jest.mock('@/lib/api', () => ({
-  API_URL: 'http://localhost:3000/api/mock', // Provide a mock API_URL
-  GEMINI_API_KEY: 'mock-gemini-key', // Provide a mock GEMINI_API_KEY
+  API_URL: 'http://localhost:3000/api/mock',
+  GEMINI_API_KEY: 'mock-gemini-key',
 }));
 
 const facturesResponse = {
@@ -28,14 +29,16 @@ const facturesResponse = {
 
 global.fetch = jest
   .fn()
-  .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(facturesResponse) })
+  .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ invoices: facturesResponse.factures }) })
   .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ id: 1, status: 'paid' }) });
 
 test('marque une facture comme payée', async () => {
   render(
-    <BrowserRouter>
-      <ListeFactures />
-    </BrowserRouter>
+    <InvoicesProvider>
+      <BrowserRouter>
+        <ListeFactures />
+      </BrowserRouter>
+    </InvoicesProvider>
   );
   await waitFor(() => expect(fetch as any).toHaveBeenCalled());
 

--- a/frontend/src/pages/ModifierFacture.tsx
+++ b/frontend/src/pages/ModifierFacture.tsx
@@ -4,7 +4,8 @@ import { ArrowLeft, Plus, Trash2, Save, Calculator } from 'lucide-react';
 import LogoDropzone from '@/components/LogoDropzone';
 import { API_URL, apiClient } from '@/lib/api';
 import { computeTotals } from '@/lib/utils';
-import { updateInvoice, cacheInvoicesLocally } from '@/utils/invoiceService';
+import { updateInvoice } from '@/utils/invoiceService';
+import { useInvoices } from '@/context/InvoicesContext';
 
 interface LigneFacture {
   description: string;
@@ -43,6 +44,7 @@ interface Facture {
 export default function ModifierFacture() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
+  const { refresh } = useInvoices();
   const goBack = () => (window.history.length > 1 ? navigate(-1) : navigate('/'));
   
   // État du formulaire
@@ -264,8 +266,7 @@ export default function ModifierFacture() {
         lignes: lignesValides,
       });
 
-      cacheInvoicesLocally([]);
-
+      await refresh();
       alert('Facture modifiée avec succès !');
       navigate(`/factures/${id}`);
     } catch (err) {


### PR DESCRIPTION
## Summary
- add `InvoicesContext` to store invoices and provide totals
- wrap layout in `InvoicesProvider`
- update invoice pages and pie chart to use the context
- refresh context after create/update/delete actions
- adjust tests for new context

## Testing
- `cd backend && pnpm install && pnpm test`
- `cd frontend && pnpm install && pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_685e07d087a8832fa9459051cda9d4b4