### PR TITLE
Revert to base frontend configs

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,8 +4,8 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "vite --debug",
-    "build": "yes | pnpm install && rm -rf node_modules/.vite-temp && tsc -b && vite build",
+    "dev": "vite",
+    "build": "vite build",
     "lint": "yes | pnpm install && eslint .",
     "preview": "yes | pnpm install && vite preview",
     "test": "jest",

--- a/frontend/src/components/cards/TotalInvoicesPie.tsx
+++ b/frontend/src/components/cards/TotalInvoicesPie.tsx
@@ -12,32 +12,39 @@ export function TotalInvoicesPie() {
   const [payees, setPayees] = useState(0);
   const [nonPayees, setNonPayees] = useState(0);
   const [isLoading, setIsLoading] = useState(true);
-  const [error, setError] = useState(false);
+  const [hasData, setHasData] = useState(true);
 
   useEffect(() => {
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), 5000);
     apiClient
       .getInvoiceSummary()
       .then(res => {
         setPayees(res.payees);
         setNonPayees(res.non_payees);
       })
-      .catch(err => {
-        console.error('Failed to fetch invoice summary', err);
-        setError(true);
+      .catch(() => {
+        setHasData(false);
       })
       .finally(() => {
-        clearTimeout(timer);
         setIsLoading(false);
       });
-    return () => {
-      controller.abort();
-      clearTimeout(timer);
-    };
   }, []);
 
   const total = payees + nonPayees;
+
+  if (isLoading) {
+    return (
+      <Card className="w-full transition-all duration-300 hover:-translate-y-1 hover:shadow-lg bg-gradient-to-br from-[var(--gradient-start)] via-[var(--gradient-mid)] to-[var(--gradient-end)] text-white dark:from-indigo-900 dark:via-violet-900 dark:to-indigo-950">
+        <CardHeader>
+          <CardTitle>Répartition des factures</CardTitle>
+        </CardHeader>
+        <CardContent className="text-center">
+          <SkeletonPie />
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (!hasData) return null;
 
   return (
     <Card className="w-full transition-all duration-300 hover:-translate-y-1 hover:shadow-lg bg-gradient-to-br from-[var(--gradient-start)] via-[var(--gradient-mid)] to-[var(--gradient-end)] text-white dark:from-indigo-900 dark:via-violet-900 dark:to-indigo-950">
@@ -45,11 +52,7 @@ export function TotalInvoicesPie() {
         <CardTitle>Répartition des factures</CardTitle>
       </CardHeader>
       <CardContent className="text-center">
-        {error ? (
-          <div className="h-40 flex items-center justify-center">Données non disponibles</div>
-        ) : isLoading ? (
-          <SkeletonPie />
-        ) : total === 0 ? (
+        {total === 0 ? (
           <div className="h-40 flex items-center justify-center">Aucune facture enregistrée</div>
         ) : (
           <PieChart width={200} height={160} data-testid="invoice-pie-chart">
@@ -68,16 +71,14 @@ export function TotalInvoicesPie() {
             <Legend verticalAlign="bottom" />
           </PieChart>
         )}
-        {!isLoading && !error && (
-          <>
-            <p className="mt-4 font-medium">
-              {total} facture{total > 1 ? 's' : ''} au total
-            </p>
-            <p className="text-sm text-gray-200">
-              {payees} payée{payees > 1 ? 's' : ''}, {nonPayees} non payée{nonPayees > 1 ? 's' : ''}
-            </p>
-          </>
-        )}
+        <>
+          <p className="mt-4 font-medium">
+            {total} facture{total > 1 ? 's' : ''} au total
+          </p>
+          <p className="text-sm text-gray-200">
+            {payees} payée{payees > 1 ? 's' : ''}, {nonPayees} non payée{nonPayees > 1 ? 's' : ''}
+          </p>
+        </>
       </CardContent>
     </Card>
   );

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -2,30 +2,14 @@ import path from 'path'
 import react from '@vitejs/plugin-react'
 import { defineConfig } from 'vite'
 
-function startupLogPlugin() {
-  return {
-    name: 'startup-log',
-    configureServer(server: any) {
-      server.httpServer?.once('listening', () => {
-        const port = server.config.server.port
-        console.log(`[vite] dev server running on port ${port}`)
-      })
-    },
-  }
-}
-
 export default defineConfig({
-  plugins: [react(), startupLogPlugin()],
+  plugins: [react()],
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),
     },
   },
-  server: {
-    port: 5173,
-    hmr: {
-      overlay: false,
-    },
-  },
+  server: {},
+  build: {},
 })
 


### PR DESCRIPTION
## Summary
- clean `TotalInvoicesPie` to remove timeout and error fallback
- restore simple Vite scripts
- drop custom log plugin and port config from Vite

## Testing
- `pnpm install && pnpm test` in `backend`
- `pnpm install && pnpm test` in `frontend`
- `npm run clean` *(fails: Missing script)*
- `npm install`
- `npm run dev` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685e25fbc5e4832fae9f095611814fa3