### PR TITLE
Restore frontend scripts

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,9 +7,10 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "yes | pnpm install && eslint .",
-    "preview": "yes | pnpm install && vite preview",
+    "preview": "vite preview",
     "test": "jest",
-    "test:e2e": "pnpm exec playwright test"
+    "test:e2e": "pnpm exec playwright test",
+    "clean": "rm -rf dist .vite"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",


### PR DESCRIPTION
## Summary
- restore basic scripts in `frontend/package.json` so `npm run clean` and `npm run dev` work again

## Testing
- `npm run clean`
- `npm install`
- `npm run dev`
- `pnpm install` && `pnpm test` in backend
- `pnpm install` && `pnpm test` in frontend

------
https://chatgpt.com/codex/tasks/task_e_685e27673514832fa117a4901c850659