### PR TITLE
Load demo data fallback

### DIFF
--- a/frontend/public/demo/clients.json
+++ b/frontend/public/demo/clients.json
@@ -1,0 +1,25 @@
+[
+  {
+    "nom_client": "Diana Renoir",
+    "nom_entreprise": "Renoir Design",
+    "email": "diana@renoirdesign.com",
+    "telephone": "0690 00 00 00",
+    "adresse_facturation": "15 rue des Arts, 97100 Basse-Terre",
+    "adresse_livraison": "15 rue des Arts, 97100 Basse-Terre",
+    "siret": "11111111100011",
+    "legal_form": "SARL",
+    "rcs_number": "Basse-Terre 111 111 111"
+  },
+  {
+    "nom_client": "Malik Johnson",
+    "nom_entreprise": "MJ Architecture",
+    "email": "malik@mj-architecture.fr",
+    "telephone": "0611223344",
+    "adresse_facturation": "42 Rue des Bâtisseurs, 75010 Paris",
+    "adresse_livraison": "42 Rue des Bâtisseurs, 75010 Paris",
+    "siret": "11223344556677",
+    "tva": "FR445566778899",
+    "legal_form": "SASU",
+    "rcs_number": "Paris 123 456 789"
+  }
+]

--- a/frontend/public/demo/invoices.json
+++ b/frontend/public/demo/invoices.json
@@ -1,0 +1,58 @@
+[
+  {
+    "clientKey": "Renoir Design",
+    "numero": "F001",
+    "status": "unpaid",
+    "description": "Site vitrine 3 pages",
+    "montant": 800,
+    "date": "2024-01-20"
+  },
+  {
+    "clientKey": "Renoir Design",
+    "numero": "F002",
+    "status": "paid",
+    "description": "Logo vectoriel",
+    "montant": 300,
+    "date": "2024-02-05"
+  },
+  {
+    "clientKey": "Renoir Design",
+    "numero": "F003",
+    "status": "unpaid",
+    "description": "Charte graphique",
+    "montant": 600,
+    "date": "2024-03-10"
+  },
+  {
+    "clientKey": "Renoir Design",
+    "numero": "F004",
+    "status": "paid",
+    "description": "Carte de visite imprimée",
+    "montant": 150,
+    "date": "2024-03-20"
+  },
+  {
+    "clientKey": "MJ Architecture",
+    "numero": "F2025-045",
+    "status": "paid",
+    "description": "Consultation chantier - Projet Rivoli",
+    "montant": 950,
+    "date": "2025-06-05"
+  },
+  {
+    "clientKey": "MJ Architecture",
+    "numero": "F2025-052",
+    "status": "unpaid",
+    "description": "Plans de rénovation – Appartement Voltaire",
+    "montant": 1400,
+    "date": "2025-06-15"
+  },
+  {
+    "clientKey": "MJ Architecture",
+    "numero": "F2025-060",
+    "status": "paid",
+    "description": "Mission express – Vérification conformité permis",
+    "montant": 550,
+    "date": "2025-06-25"
+  }
+]

--- a/frontend/src/pages/Clients.tsx
+++ b/frontend/src/pages/Clients.tsx
@@ -43,6 +43,7 @@ export default function Clients() {
   const [clients, setClients] = useState<Client[]>([])
   const [isLoading, setIsLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+  const [usingDemoData, setUsingDemoData] = useState(false)
   const navigate = useNavigate()
   // New client form state
   const [nom, setNom] = useState('') // Nom / Raison sociale (uses nom_client for individual, entreprise for company)
@@ -103,9 +104,22 @@ export default function Clients() {
       const data = await apiClient.getClients();
       console.log('Clients récupérés:', data)
       setClients(data);
+      setUsingDemoData(false);
     } catch (err: any) {
       console.error('Erreur chargement clients:', err);
       setError('Erreur lors du chargement des clients.');
+      const isDev = process.env.NODE_ENV === 'development';
+      if (isDev) {
+        try {
+          const res = await fetch('/demo/clients.json');
+          const demo = await res.json();
+          setClients(demo);
+          setUsingDemoData(true);
+          setError(null);
+        } catch (demoErr) {
+          console.error('Erreur chargement données de démo:', demoErr);
+        }
+      }
     } finally {
       setIsLoading(false);
     }
@@ -249,6 +263,11 @@ export default function Clients() {
 
   return (
     <div className="p-6 space-y-6">
+      {usingDemoData && (
+        <div className="bg-yellow-100 text-yellow-800 text-center py-1 text-sm">
+          ⚠️ Données de démo affichées
+        </div>
+      )}
       <button
         type="button"
         onClick={() => (window.history.length > 1 ? navigate(-1) : navigate('/'))}

--- a/frontend/src/pages/ListeFactures.tsx
+++ b/frontend/src/pages/ListeFactures.tsx
@@ -48,7 +48,13 @@ interface PaginationInfo {
 
 export default function ListeFactures() {
   const location = useLocation();
-  const { invoices: factures, isLoading: loading, error, refresh } = useInvoices();
+  const {
+    invoices: factures,
+    isLoading: loading,
+    error,
+    refresh,
+    usingDemoData,
+  } = useInvoices();
   const [pagination, setPagination] = useState<PaginationInfo>({
     page: 1,
     limit: 10,
@@ -216,6 +222,11 @@ export default function ListeFactures() {
 
   return (
     <div className="min-h-screen">
+      {usingDemoData && (
+        <div className="bg-yellow-100 text-yellow-800 text-center py-1 text-sm">
+          ⚠️ Données de démo affichées
+        </div>
+      )}
       {/* Header */}
       <header
         className="bg-gradient-to-r from-[var(--gradient-start)] via-[var(--gradient-mid)] to-[var(--gradient-end)] text-white shadow-sm border-b border-gray-200"


### PR DESCRIPTION
## Summary
- show yellow notice when demo data is displayed
- load demo invoices and clients when API fails in development
- include demo clients/invoices in public folder

## Testing
- `cd backend && pnpm install && pnpm test`
- `cd frontend && pnpm install && pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_685e291df790832f93bb560fb81ad504