### PR TITLE
Fix client display in invoice list

### DIFF
--- a/frontend/src/pages/ListeFactures.test.tsx
+++ b/frontend/src/pages/ListeFactures.test.tsx
@@ -6,12 +6,14 @@ import { InvoicesProvider } from '@/context/InvoicesContext';
 
 // Mock the api module
 const mockGetInvoices = jest.fn();
+const mockGetClients = jest.fn();
 jest.mock('@/lib/api', () => {
   return {
     API_URL: 'http://localhost:3000/api/mock',
     GEMINI_API_KEY: 'mock-gemini-key',
     apiClient: {
       getInvoices: (...args: any[]) => mockGetInvoices(...args),
+      getClients: (...args: any[]) => mockGetClients(...args),
       getInvoiceSummary: jest.fn(),
     },
   };
@@ -35,6 +37,7 @@ const facturesResponse = {
 };
 
 mockGetInvoices.mockResolvedValue(facturesResponse.factures);
+mockGetClients.mockResolvedValue([]);
 
 global.fetch = jest
   .fn()


### PR DESCRIPTION
## Summary
- load client data on invoice list page
- show client name or company by joining invoice and client
- mock `getClients` in invoice list tests

## Testing
- `cd backend && pnpm install && pnpm test`
- `cd frontend && pnpm install && pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_685e2ca044f8832fb9bebadd5986563d